### PR TITLE
Update generator script to Clang.jl 0.14(master)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ CImGui = "5d785b6c-b76f-510e-a07c-3070796c7e87"
 CImPlot_jll = "278f1f02-c5a0-563f-9174-e8b244dda450"
 
 [compat]
+CEnum = "0.4"
 CImGui = "~1.79.0"
 CImPlot_jll = "0.8.0"
 julia = "1.3"

--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -1,0 +1,151 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[CEnum]]
+git-tree-sha1 = "215a9aa4a1f23fbd05b92769fdd62559488d70e9"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.4.1"
+
+[[CImGui_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "880a144921b99bf92b39bbf99817706391bf2448"
+uuid = "7dd61d3b-0da5-5c94-bbf9-a0296c6e3925"
+version = "1.79.0+0"
+
+[[Clang]]
+deps = ["CEnum", "Clang_jll", "Downloads", "Pkg", "TOML"]
+git-tree-sha1 = "93b424759f11b7dbd300eb424fa1bfe590e15cf6"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaInterop/Clang.jl.git"
+uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+version = "0.14.0"
+
+[[Clang_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "libLLVM_jll"]
+git-tree-sha1 = "a5923c06de3178dd755f4b9411ea8922a7ae6fb8"
+uuid = "0ee61d77-7f21-5576-8119-9fcc46b10100"
+version = "11.0.1+3"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.3.0"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.2"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[libLLVM_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+CImGui_jll = "7dd61d3b-0da5-5c94-bbf9-a0296c6e3925"
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+
+[compat]
+CEnum = "0.2,0.3,0.4"
+CImGui_jll = "~1.79.0"
+Clang = "0.14.0"

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -1,7 +1,5 @@
 using Clang.Generators
-
 # using ImPlot.LibCImPlot.CImPlot_jll
-
 using CImGui_jll
 
 include_dir = joinpath(CImGui_jll.artifact_dir, "include")
@@ -12,32 +10,33 @@ const CIMPLOT_H = joinpath(@__DIR__, "cimplot_patched.h") |> normpath
 
 options = load_options(joinpath(@__DIR__, "generator.toml"))
 
-args = ["-I$include_dir", "-DCIMGUI_DEFINE_ENUMS_AND_STRUCTS"]
+args = get_default_args()
+push!(args, "-isystem$include_dir", "-DCIMGUI_DEFINE_ENUMS_AND_STRUCTS")
 
 # add definitions
-@add_def ImVec2
-@add_def ImVec4
-@add_def ImGuiMouseButton
-@add_def ImGuiKeyModFlags
-@add_def ImS8
-@add_def ImU8
-@add_def ImS16
-@add_def ImU16
-@add_def ImS32
-@add_def ImU32
-@add_def ImS64
-@add_def ImU64
-@add_def ImTextureID
-@add_def ImGuiCond
-@add_def ImGuiDragDropFlags
-@add_def ImDrawList
-@add_def ImGuiContext
+# @add_def ImVec2
+# @add_def ImVec4
+# @add_def ImGuiMouseButton
+# @add_def ImGuiKeyModFlags
+# @add_def ImS8
+# @add_def ImU8
+# @add_def ImS16
+# @add_def ImU16
+# @add_def ImS32
+# @add_def ImU32
+# @add_def ImS64
+# @add_def ImU64
+# @add_def ImTextureID
+# @add_def ImGuiCond
+# @add_def ImGuiDragDropFlags
+# @add_def ImDrawList
+# @add_def ImGuiContext
 
 #=
 jltypes = [Float32, Float64, Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64]
 typedict = Dict(zip(imtypes,jltypes))
 =#
-#type_names = ["FloatPtr", "doublePtr", "S8Ptr", "U8Ptr", "S16Ptr", "U16Ptr", "S32Ptr", "U32Ptr", "S64Ptr", "U64Ptr"]  
+#type_names = ["FloatPtr", "doublePtr", "S8Ptr", "U8Ptr", "S16Ptr", "U16Ptr", "S32Ptr", "U32Ptr", "S64Ptr", "U64Ptr"]
 
 imdatatypes = [:Cfloat, :Cdouble, :ImS8, :ImU8, :ImS16, :ImU16, :ImS32, :ImU32, :ImS64, :ImU64]
 plot_types = ["Line", "Scatter", "Stairs", "Shaded", "BarsH", "Bars", "ErrorBarsH", "ErrorBars", "Stems", "VLines", "HLines", "PieChart", "Heatmap", "Histogram", "Histogram2D", "Digital"]
@@ -47,7 +46,7 @@ ctx = create_context(CIMPLOT_H, args, options)
 build!(ctx, BUILDSTAGE_NO_PRINTING)
 
 function revise_function!(e::Expr)
-    
+
     # Get name of the function
     fname = string(e.args[1].args[1])
 
@@ -61,12 +60,12 @@ function revise_function!(e::Expr)
     if startswith(fname, "Plot")
 
         # iterate the tuple of C argument types in the function's ccall
-        cargtypes = e.args[2].args[1].args[4].args    
+        cargtypes = e.args[2].args[1].args[4].args
         for (i, cargtype) in enumerate(cargtypes)
-            
+
             # All pointers in plot functions (where eltype ∈ imdatatypes) are array inputs
-            if (Meta.isexpr(cargtype, :curly) && cargtype.args[1] == :Ptr) && cargtype.args[2] ∈ imdatatypes 
-                
+            if (Meta.isexpr(cargtype, :curly) && cargtype.args[1] == :Ptr) && cargtype.args[2] ∈ imdatatypes
+
                 # Input arrays allocated in Julia should be passed as Ref: https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/#When-to-use-T,-Ptr{T}-and-Ref{T}
                 e.args[2].args[1].args[4].args[i].args[1] = :Ref
 
@@ -104,9 +103,9 @@ function revise_function!(e::Expr)
             end
         end
     end
-             
+
     e.args[1].args[1] = Symbol(fname)
-    return e 
+    return e
 end
 
 function rewrite!(dag::ExprDAG)

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -1,106 +1,18 @@
 [general]
-# it could also be an expression as long as `Meta.parse` can parse this string successfully.
-# basically, it should be the `expression` in the following code:
-# ccall((function_name, expression), returntype, (argtype1, ...), argvalue1, ...)
 library_name = "libcimplot"
-
-# the new generator is able to print everthing into one single file instead of a pair of two files.
 output_file_path = "../src/libcimplot.jl"
-
-# if this entry is not empty, the generator will print the code below to the `output_file_path`.
-# module module_name
-# 
-# end # module
 module_name = "LibCImPlot"
-
-# if this entry is not empty, the generator will print the code below to the `output_file_path`.
-# using jll_pkg_name
-# export jll_pkg_name
-# jll_pkg_name = "CImPlot_jll"
-
-# identifiers that starts with the string listed in this entry will be exported.
 export_symbol_prefixes = ["ImPlotFlags_", "ImPlotAxisFlags_", "ImPlotCol_", "ImPlotStyleVar_",
                           "ImPlotMarker_", "ImPlotColormap_", "ImPlotLocation_",
                           "ImPlotOrientation_", "ImPlotYAxis_"]
-
-# the code in the following file will be copy-pasted to `output_file_path` before the generated code.
-# this is often used for applying custom patches, e.g. adding missing definitions.
 prologue_file_path = "./prologue.jl"
-
-# the code in the following file will be copy-pasted to `output_file_path` after the generated code.
-# this is often used for applying custom patches.
 epilogue_file_path = "./epilogue.jl"
 
-# automatically detect system std headers especially for macOS users.
-auto_detect_system_headers = true
-
-# header blacklist
-header_blacklist = []
-
-# node with an id in the `printer_blacklist` will be ignored in the printing passes. 
-# this is very useful for custom editing. 
 printer_blacklist = ["CIMGUIPLOT_INCLUDED"]
 
-# Julia's `@enum` do not allow duplicated values, so by default, C enums are translated to 
-# CEnum.jl's `@cenum`. 
-# if this entry is true, those duplicated enum constants are commented. 
-use_julia_native_enum_type = false
-
-# by default, only those declarations in the local header file are processed. 
-# for example, those declarations in the standard C library will be ignored. 
-# if you'd like to disable this behavior, please set this option to false.
-is_local_header_only = true
-
-# by default, we skip all of those compiler declarations.
-skip_compiler_definition = true
-
-# run `DeAnonymize` pass if this option is set to true.
-smart_de_anonymize = true
-
-# if this option is set to true, those structs that are not necessary to be an 
-# immutable struct will be changed to be a mutable struct. 
-# this option is default to false, do read the paragraph below before using this feature.
 auto_mutability = true
-
-# if you feel like certain structs should not be generated as mutable struct, please add them in the following list. 
-# for example, if a C function accepts a vector of some type as its argument:
-#     void foo(mutable_type *list, int n);
-# when calling this function via `ccall`, passing a `Vector{mutable_type}(undef, n)` to the first
-# argument will trigger a crash, one needs to use `Ref{NTuple{n,mutable_type}}()` instead.
-# this is not convenient and that's where the `auto_mutability_blacklist` comes in.
 auto_mutability_blacklist = []
-
-# opposite to `auto_mutability_blacklist` and has a higher priority
 auto_mutability_whitelist = []
 
-[codegen]
-# map C's bool to Julia's Bool instead of `Cuchar` a.k.a `UInt8`.
-use_julia_bool = true
-
-# set this to true if the C routine always expects a NUL-terminated string.
-# TODO: support filtering
-always_NUL_terminated_string = true
-
-# generate strictly typed function
-is_function_strictly_typed = false
-
-# if true, opaque pointers in function arguments will be translated to `Ptr{Cvoid}`.
-opaque_func_arg_as_PtrCvoid = false
-
-# if true, opaque types are translated to `mutable struct` instead of `Cvoid`.
-opaque_as_mutable_struct = true
-
 [codegen.macro]
-# it highly recommended to set this entry to "basic".
-# if you'd like to skip all of the macros, please set this entry to "disable".
-# if you'd like to aggressive translate macros to Julia, please set this entry to "aggressive".
 macro_mode = "basic"
-
-# if this entry is true, the generator prints the following message as comments.
-# "# Skipping MacroDefinition: ..."
-add_comment_for_skipped_macro = true
-
-# ignore any macros that is suffixed with "_H"
-ignore_header_guards = true
-
-[general.log]

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -8,7 +8,7 @@ export_symbol_prefixes = ["ImPlotFlags_", "ImPlotAxisFlags_", "ImPlotCol_", "ImP
 prologue_file_path = "./prologue.jl"
 epilogue_file_path = "./epilogue.jl"
 
-printer_blacklist = ["CIMGUIPLOT_INCLUDED"]
+printer_blacklist = ["CIMGUIPLOT_INCLUDED", "CIMGUI_API", "CONST"]
 
 auto_mutability = true
 auto_mutability_blacklist = []

--- a/gen/prologue.jl
+++ b/gen/prologue.jl
@@ -2,19 +2,16 @@ using CImPlot_jll
 
 using CImGui
 
-import CImGui: 
-    # Vector primitives:
-    ImVec2, ImVec4,
-    # Enums
-    ImGuiMouseButton, ImGuiKeyModFlags, ImGuiCond, ImGuiDragDropFlags,
-    # Primitive type aliases; uncomment after CImGui update
-    #=ImS8,=# ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64,
-    ImTextureID,
-    ImDrawList,
-    ImGuiContext
-            
-#Temporary patch; CImGui.jl v1.79.0 aliases ImS8 incorrectly
-const ImS8 = Int8
+# import CImGui:
+#     # Vector primitives:
+#     ImVec2, ImVec4,
+#     # Enums
+#     ImGuiMouseButton, ImGuiKeyModFlags, ImGuiCond, ImGuiDragDropFlags,
+#     # Primitive type aliases; uncomment after CImGui update
+#     #=ImS8,=# ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64,
+#     ImTextureID,
+#     ImDrawList,
+#     ImGuiContext
 
-const IMPLOT_AUTO = Cint(-1)
-const IMPLOT_AUTO_COL = ImVec4(0,0,0,-1)
+# #Temporary patch; CImGui.jl v1.79.0 aliases ImS8 incorrectly
+# const ImS8 = Int8

--- a/src/libcimplot.jl
+++ b/src/libcimplot.jl
@@ -4,25 +4,1300 @@ using CEnum
 
 using CImPlot_jll
 
-using CImGui
 
-import CImGui: 
-    # Vector primitives:
-    ImVec2, ImVec4,
-    # Enums
-    ImGuiMouseButton, ImGuiKeyModFlags, ImGuiCond, ImGuiDragDropFlags,
-    # Primitive type aliases; uncomment after CImGui update
-    #=ImS8,=# ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64,
-    ImTextureID,
-    ImDrawList,
-    ImGuiContext
-            
-#Temporary patch; CImGui.jl v1.79.0 aliases ImS8 incorrectly
+struct ImGuiPtrOrIndex
+    Ptr::Ptr{Cvoid}
+    Index::Cint
+end
+
+struct ImGuiShrinkWidthItem
+    Index::Cint
+    Width::Cfloat
+end
+
+struct ImVec2ih
+    x::Cshort
+    y::Cshort
+end
+
+struct ImVec1
+    x::Cfloat
+end
+
+struct StbUndoRecord
+    where::Cint
+    insert_length::Cint
+    delete_length::Cint
+    char_storage::Cint
+end
+
+const ImWchar16 = Cushort
+
+const ImWchar = ImWchar16
+
+struct StbUndoState
+    undo_rec::NTuple{99, StbUndoRecord}
+    undo_char::NTuple{999, ImWchar}
+    undo_point::Cshort
+    redo_point::Cshort
+    undo_char_point::Cint
+    redo_char_point::Cint
+end
+
+struct STB_TexteditState
+    cursor::Cint
+    select_start::Cint
+    select_end::Cint
+    insert_mode::Cuchar
+    row_count_per_page::Cint
+    cursor_at_end_of_line::Cuchar
+    initialized::Cuchar
+    has_preferred_x::Cuchar
+    single_line::Cuchar
+    padding1::Cuchar
+    padding2::Cuchar
+    padding3::Cuchar
+    preferred_x::Cfloat
+    undostate::StbUndoState
+end
+
+const ImGuiID = Cuint
+
+struct ImGuiWindowSettings
+    ID::ImGuiID
+    Pos::ImVec2ih
+    Size::ImVec2ih
+    Collapsed::Bool
+    WantApply::Bool
+end
+
+struct ImVec2
+    x::Cfloat
+    y::Cfloat
+end
+
+const ImGuiItemStatusFlags = Cint
+
+struct ImRect
+    Min::ImVec2
+    Max::ImVec2
+end
+
+@cenum ImGuiNavLayer::UInt32 begin
+    ImGuiNavLayer_Main = 0
+    ImGuiNavLayer_Menu = 1
+    ImGuiNavLayer_COUNT = 2
+end
+
+struct ImGuiMenuColumns
+    Spacing::Cfloat
+    Width::Cfloat
+    NextWidth::Cfloat
+    Pos::NTuple{3, Cfloat}
+    NextWidths::NTuple{3, Cfloat}
+end
+
+const ImU32 = Cuint
+
+struct ImVector_ImGuiWindowPtr
+    Size::Cint
+    Capacity::Cint
+    # Data::Ptr{Ptr{ImGuiWindow}}
+    Data::Ptr{Ptr{Cvoid}}
+end
+
+function Base.getproperty(x::ImVector_ImGuiWindowPtr, f::Symbol)
+    f === :Data && return Ptr{Ptr{ImGuiWindow}}(getfield(x, f))
+    return getfield(x, f)
+end
+
+struct ImGuiStoragePair
+    data::NTuple{16, UInt8}
+end
+
+function Base.getproperty(x::Ptr{ImGuiStoragePair}, f::Symbol)
+    f === :key && return Ptr{ImGuiID}(x + 0)
+    f === :val_i && return Ptr{Cint}(x + 8)
+    f === :val_f && return Ptr{Cfloat}(x + 8)
+    f === :val_p && return Ptr{Ptr{Cvoid}}(x + 8)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::ImGuiStoragePair, f::Symbol)
+    r = Ref{ImGuiStoragePair}(x)
+    ptr = Base.unsafe_convert(Ptr{ImGuiStoragePair}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{ImGuiStoragePair}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+struct ImVector_ImGuiStoragePair
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiStoragePair}
+end
+
+struct ImGuiStorage
+    Data::ImVector_ImGuiStoragePair
+end
+
+const ImGuiColumnsFlags = Cint
+
+struct ImGuiColumnData
+    OffsetNorm::Cfloat
+    OffsetNormBeforeResize::Cfloat
+    Flags::ImGuiColumnsFlags
+    ClipRect::ImRect
+end
+
+struct ImVector_ImGuiColumnData
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiColumnData}
+end
+
+struct ImVec4
+    x::Cfloat
+    y::Cfloat
+    z::Cfloat
+    w::Cfloat
+end
+
+const ImTextureID = Ptr{Cvoid}
+
+# typedef void ( * ImDrawCallback ) ( const ImDrawList * parent_list , const ImDrawCmd * cmd )
+const ImDrawCallback = Ptr{Cvoid}
+
+struct ImDrawCmd
+    ClipRect::ImVec4
+    TextureId::ImTextureID
+    VtxOffset::Cuint
+    IdxOffset::Cuint
+    ElemCount::Cuint
+    UserCallback::ImDrawCallback
+    UserCallbackData::Ptr{Cvoid}
+end
+
+struct ImVector_ImDrawCmd
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImDrawCmd}
+end
+
+const ImDrawIdx = Cushort
+
+struct ImVector_ImDrawIdx
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImDrawIdx}
+end
+
+struct ImDrawChannel
+    _CmdBuffer::ImVector_ImDrawCmd
+    _IdxBuffer::ImVector_ImDrawIdx
+end
+
+struct ImVector_ImDrawChannel
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImDrawChannel}
+end
+
+struct ImDrawListSplitter
+    _Current::Cint
+    _Count::Cint
+    _Channels::ImVector_ImDrawChannel
+end
+
+struct ImGuiColumns
+    ID::ImGuiID
+    Flags::ImGuiColumnsFlags
+    IsFirstFrame::Bool
+    IsBeingResized::Bool
+    Current::Cint
+    Count::Cint
+    OffMinX::Cfloat
+    OffMaxX::Cfloat
+    LineMinY::Cfloat
+    LineMaxY::Cfloat
+    HostCursorPosY::Cfloat
+    HostCursorMaxPosX::Cfloat
+    HostInitialClipRect::ImRect
+    HostBackupClipRect::ImRect
+    HostBackupParentWorkRect::ImRect
+    Columns::ImVector_ImGuiColumnData
+    Splitter::ImDrawListSplitter
+end
+
+const ImGuiLayoutType = Cint
+
+const ImGuiItemFlags = Cint
+
+struct ImVector_ImGuiItemFlags
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiItemFlags}
+end
+
+struct ImVector_float
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{Cfloat}
+end
+
+struct ImGuiGroupData
+    BackupCursorPos::ImVec2
+    BackupCursorMaxPos::ImVec2
+    BackupIndent::ImVec1
+    BackupGroupOffset::ImVec1
+    BackupCurrLineSize::ImVec2
+    BackupCurrLineTextBaseOffset::Cfloat
+    BackupActiveIdIsAlive::ImGuiID
+    BackupActiveIdPreviousFrameIsAlive::Bool
+    EmitItem::Bool
+end
+
+struct ImVector_ImGuiGroupData
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiGroupData}
+end
+
+struct ImGuiWindowTempData
+    CursorPos::ImVec2
+    CursorPosPrevLine::ImVec2
+    CursorStartPos::ImVec2
+    CursorMaxPos::ImVec2
+    CurrLineSize::ImVec2
+    PrevLineSize::ImVec2
+    CurrLineTextBaseOffset::Cfloat
+    PrevLineTextBaseOffset::Cfloat
+    Indent::ImVec1
+    ColumnsOffset::ImVec1
+    GroupOffset::ImVec1
+    LastItemId::ImGuiID
+    LastItemStatusFlags::ImGuiItemStatusFlags
+    LastItemRect::ImRect
+    LastItemDisplayRect::ImRect
+    NavLayerCurrent::ImGuiNavLayer
+    NavLayerActiveMask::Cint
+    NavLayerActiveMaskNext::Cint
+    NavFocusScopeIdCurrent::ImGuiID
+    NavHideHighlightOneFrame::Bool
+    NavHasScroll::Bool
+    MenuBarAppending::Bool
+    MenuBarOffset::ImVec2
+    MenuColumns::ImGuiMenuColumns
+    TreeDepth::Cint
+    TreeJumpToParentOnPopMask::ImU32
+    ChildWindows::ImVector_ImGuiWindowPtr
+    StateStorage::Ptr{ImGuiStorage}
+    CurrentColumns::Ptr{ImGuiColumns}
+    LayoutType::ImGuiLayoutType
+    ParentLayoutType::ImGuiLayoutType
+    FocusCounterRegular::Cint
+    FocusCounterTabStop::Cint
+    ItemFlags::ImGuiItemFlags
+    ItemWidth::Cfloat
+    TextWrapPos::Cfloat
+    ItemFlagsStack::ImVector_ImGuiItemFlags
+    ItemWidthStack::ImVector_float
+    TextWrapPosStack::ImVector_float
+    GroupStack::ImVector_ImGuiGroupData
+    StackSizesBackup::NTuple{6, Cshort}
+end
+
+const ImGuiWindowFlags = Cint
+
 const ImS8 = Int8
 
-const IMPLOT_AUTO = Cint(-1)
-const IMPLOT_AUTO_COL = ImVec4(0,0,0,-1)
+const ImGuiDir = Cint
 
+const ImGuiCond = Cint
+
+struct ImVector_ImGuiID
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiID}
+end
+
+struct ImVector_ImGuiColumns
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiColumns}
+end
+
+struct ImDrawVert
+    pos::ImVec2
+    uv::ImVec2
+    col::ImU32
+end
+
+struct ImVector_ImDrawVert
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImDrawVert}
+end
+
+const ImDrawListFlags = Cint
+
+struct ImVector_ImVec4
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImVec4}
+end
+
+struct ImVector_ImTextureID
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImTextureID}
+end
+
+struct ImVector_ImVec2
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImVec2}
+end
+
+struct ImDrawList
+    CmdBuffer::ImVector_ImDrawCmd
+    IdxBuffer::ImVector_ImDrawIdx
+    VtxBuffer::ImVector_ImDrawVert
+    Flags::ImDrawListFlags
+    # _Data::Ptr{ImDrawListSharedData}
+    _Data::Ptr{Cvoid}
+    _OwnerName::Ptr{Cchar}
+    _VtxCurrentIdx::Cuint
+    _VtxWritePtr::Ptr{ImDrawVert}
+    _IdxWritePtr::Ptr{ImDrawIdx}
+    _ClipRectStack::ImVector_ImVec4
+    _TextureIdStack::ImVector_ImTextureID
+    _Path::ImVector_ImVec2
+    _CmdHeader::ImDrawCmd
+    _Splitter::ImDrawListSplitter
+end
+
+function Base.getproperty(x::ImDrawList, f::Symbol)
+    f === :_Data && return Ptr{ImDrawListSharedData}(getfield(x, f))
+    return getfield(x, f)
+end
+
+struct ImGuiWindow
+    Name::Ptr{Cchar}
+    ID::ImGuiID
+    Flags::ImGuiWindowFlags
+    Pos::ImVec2
+    Size::ImVec2
+    SizeFull::ImVec2
+    ContentSize::ImVec2
+    ContentSizeExplicit::ImVec2
+    WindowPadding::ImVec2
+    WindowRounding::Cfloat
+    WindowBorderSize::Cfloat
+    NameBufLen::Cint
+    MoveId::ImGuiID
+    ChildId::ImGuiID
+    Scroll::ImVec2
+    ScrollMax::ImVec2
+    ScrollTarget::ImVec2
+    ScrollTargetCenterRatio::ImVec2
+    ScrollTargetEdgeSnapDist::ImVec2
+    ScrollbarSizes::ImVec2
+    ScrollbarX::Bool
+    ScrollbarY::Bool
+    Active::Bool
+    WasActive::Bool
+    WriteAccessed::Bool
+    Collapsed::Bool
+    WantCollapseToggle::Bool
+    SkipItems::Bool
+    Appearing::Bool
+    Hidden::Bool
+    IsFallbackWindow::Bool
+    HasCloseButton::Bool
+    ResizeBorderHeld::Int8
+    BeginCount::Cshort
+    BeginOrderWithinParent::Cshort
+    BeginOrderWithinContext::Cshort
+    PopupId::ImGuiID
+    AutoFitFramesX::ImS8
+    AutoFitFramesY::ImS8
+    AutoFitChildAxises::ImS8
+    AutoFitOnlyGrows::Bool
+    AutoPosLastDirection::ImGuiDir
+    HiddenFramesCanSkipItems::Cint
+    HiddenFramesCannotSkipItems::Cint
+    SetWindowPosAllowFlags::ImGuiCond
+    SetWindowSizeAllowFlags::ImGuiCond
+    SetWindowCollapsedAllowFlags::ImGuiCond
+    SetWindowPosVal::ImVec2
+    SetWindowPosPivot::ImVec2
+    IDStack::ImVector_ImGuiID
+    DC::ImGuiWindowTempData
+    OuterRectClipped::ImRect
+    InnerRect::ImRect
+    InnerClipRect::ImRect
+    WorkRect::ImRect
+    ParentWorkRect::ImRect
+    ClipRect::ImRect
+    ContentRegionRect::ImRect
+    HitTestHoleSize::ImVec2ih
+    HitTestHoleOffset::ImVec2ih
+    LastFrameActive::Cint
+    LastTimeActive::Cfloat
+    ItemWidthDefault::Cfloat
+    StateStorage::ImGuiStorage
+    ColumnsStorage::ImVector_ImGuiColumns
+    FontWindowScale::Cfloat
+    SettingsOffset::Cint
+    DrawList::Ptr{ImDrawList}
+    DrawListInst::ImDrawList
+    ParentWindow::Ptr{ImGuiWindow}
+    RootWindow::Ptr{ImGuiWindow}
+    RootWindowForTitleBarHighlight::Ptr{ImGuiWindow}
+    RootWindowForNav::Ptr{ImGuiWindow}
+    NavLastChildNavWindow::Ptr{ImGuiWindow}
+    NavLastIds::NTuple{2, ImGuiID}
+    NavRectRel::NTuple{2, ImRect}
+    MemoryCompacted::Bool
+    MemoryDrawListIdxCapacity::Cint
+    MemoryDrawListVtxCapacity::Cint
+end
+
+const ImGuiTabItemFlags = Cint
+
+const ImS16 = Cshort
+
+struct ImGuiTabItem
+    ID::ImGuiID
+    Flags::ImGuiTabItemFlags
+    LastFrameVisible::Cint
+    LastFrameSelected::Cint
+    Offset::Cfloat
+    Width::Cfloat
+    ContentWidth::Cfloat
+    NameOffset::ImS16
+    BeginOrder::ImS8
+    IndexDuringLayout::ImS8
+    WantClose::Bool
+end
+
+struct ImVector_ImGuiTabItem
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiTabItem}
+end
+
+const ImGuiTabBarFlags = Cint
+
+struct ImVector_char
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{Cchar}
+end
+
+struct ImGuiTextBuffer
+    Buf::ImVector_char
+end
+
+struct ImGuiTabBar
+    Tabs::ImVector_ImGuiTabItem
+    ID::ImGuiID
+    SelectedTabId::ImGuiID
+    NextSelectedTabId::ImGuiID
+    VisibleTabId::ImGuiID
+    CurrFrameVisible::Cint
+    PrevFrameVisible::Cint
+    BarRect::ImRect
+    LastTabContentHeight::Cfloat
+    WidthAllTabs::Cfloat
+    WidthAllTabsIdeal::Cfloat
+    ScrollingAnim::Cfloat
+    ScrollingTarget::Cfloat
+    ScrollingTargetDistToVisibility::Cfloat
+    ScrollingSpeed::Cfloat
+    ScrollingRectMinX::Cfloat
+    ScrollingRectMaxX::Cfloat
+    Flags::ImGuiTabBarFlags
+    ReorderRequestTabId::ImGuiID
+    ReorderRequestDir::ImS8
+    TabsActiveCount::ImS8
+    WantLayout::Bool
+    VisibleTabWasSubmitted::Bool
+    TabsAddedNew::Bool
+    LastTabItemIdx::Cshort
+    FramePadding::ImVec2
+    TabsNames::ImGuiTextBuffer
+end
+
+const ImGuiStyleVar = Cint
+
+struct ImGuiStyleMod
+    data::NTuple{12, UInt8}
+end
+
+function Base.getproperty(x::Ptr{ImGuiStyleMod}, f::Symbol)
+    f === :VarIdx && return Ptr{ImGuiStyleVar}(x + 0)
+    f === :BackupInt && return Ptr{NTuple{2, Cint}}(x + 4)
+    f === :BackupFloat && return Ptr{NTuple{2, Cfloat}}(x + 4)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::ImGuiStyleMod, f::Symbol)
+    r = Ref{ImGuiStyleMod}(x)
+    ptr = Base.unsafe_convert(Ptr{ImGuiStyleMod}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{ImGuiStyleMod}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+struct ImGuiSettingsHandler
+    TypeName::Ptr{Cchar}
+    TypeHash::ImGuiID
+    ClearAllFn::Ptr{Cvoid}
+    ReadInitFn::Ptr{Cvoid}
+    ReadOpenFn::Ptr{Cvoid}
+    ReadLineFn::Ptr{Cvoid}
+    ApplyAllFn::Ptr{Cvoid}
+    WriteAllFn::Ptr{Cvoid}
+    UserData::Ptr{Cvoid}
+end
+
+struct ImGuiPopupData
+    PopupId::ImGuiID
+    Window::Ptr{ImGuiWindow}
+    SourceWindow::Ptr{ImGuiWindow}
+    OpenFrameCount::Cint
+    OpenParentId::ImGuiID
+    OpenPopupPos::ImVec2
+    OpenMousePos::ImVec2
+end
+
+const ImGuiNextItemDataFlags = Cint
+
+struct ImGuiNextItemData
+    Flags::ImGuiNextItemDataFlags
+    Width::Cfloat
+    FocusScopeId::ImGuiID
+    OpenCond::ImGuiCond
+    OpenVal::Bool
+end
+
+const ImGuiNextWindowDataFlags = Cint
+
+# typedef void ( * ImGuiSizeCallback ) ( ImGuiSizeCallbackData * data )
+const ImGuiSizeCallback = Ptr{Cvoid}
+
+struct ImGuiNextWindowData
+    Flags::ImGuiNextWindowDataFlags
+    PosCond::ImGuiCond
+    SizeCond::ImGuiCond
+    CollapsedCond::ImGuiCond
+    PosVal::ImVec2
+    PosPivotVal::ImVec2
+    SizeVal::ImVec2
+    ContentSizeVal::ImVec2
+    ScrollVal::ImVec2
+    CollapsedVal::Bool
+    SizeConstraintRect::ImRect
+    SizeCallback::ImGuiSizeCallback
+    SizeCallbackUserData::Ptr{Cvoid}
+    BgAlphaVal::Cfloat
+    MenuBarOffsetMinVal::ImVec2
+end
+
+struct ImGuiNavMoveResult
+    Window::Ptr{ImGuiWindow}
+    ID::ImGuiID
+    FocusScopeId::ImGuiID
+    DistBox::Cfloat
+    DistCenter::Cfloat
+    DistAxial::Cfloat
+    RectRel::ImRect
+end
+
+struct ImVector_ImWchar
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImWchar}
+end
+
+const ImGuiInputTextFlags = Cint
+
+# typedef int ( * ImGuiInputTextCallback ) ( ImGuiInputTextCallbackData * data )
+const ImGuiInputTextCallback = Ptr{Cvoid}
+
+struct ImGuiInputTextState
+    ID::ImGuiID
+    CurLenW::Cint
+    CurLenA::Cint
+    TextW::ImVector_ImWchar
+    TextA::ImVector_char
+    InitialTextA::ImVector_char
+    TextAIsValid::Bool
+    BufCapacityA::Cint
+    ScrollX::Cfloat
+    Stb::STB_TexteditState
+    CursorAnim::Cfloat
+    CursorFollow::Bool
+    SelectedAllMouseLock::Bool
+    Edited::Bool
+    UserFlags::ImGuiInputTextFlags
+    UserCallback::ImGuiInputTextCallback
+    UserCallbackData::Ptr{Cvoid}
+end
+
+const ImGuiCol = Cint
+
+struct ImGuiColorMod
+    Col::ImGuiCol
+    BackupValue::ImVec4
+end
+
+struct ImVector_ImDrawListPtr
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{Ptr{ImDrawList}}
+end
+
+struct ImDrawDataBuilder
+    Layers::NTuple{2, ImVector_ImDrawListPtr}
+end
+
+struct ImFontAtlasCustomRect
+    Width::Cushort
+    Height::Cushort
+    X::Cushort
+    Y::Cushort
+    GlyphID::Cuint
+    GlyphAdvanceX::Cfloat
+    GlyphOffset::ImVec2
+    # Font::Ptr{ImFont}
+    Font::Ptr{Cvoid}
+end
+
+function Base.getproperty(x::ImFontAtlasCustomRect, f::Symbol)
+    f === :Font && return Ptr{ImFont}(getfield(x, f))
+    return getfield(x, f)
+end
+
+struct ImGuiStyle
+    Alpha::Cfloat
+    WindowPadding::ImVec2
+    WindowRounding::Cfloat
+    WindowBorderSize::Cfloat
+    WindowMinSize::ImVec2
+    WindowTitleAlign::ImVec2
+    WindowMenuButtonPosition::ImGuiDir
+    ChildRounding::Cfloat
+    ChildBorderSize::Cfloat
+    PopupRounding::Cfloat
+    PopupBorderSize::Cfloat
+    FramePadding::ImVec2
+    FrameRounding::Cfloat
+    FrameBorderSize::Cfloat
+    ItemSpacing::ImVec2
+    ItemInnerSpacing::ImVec2
+    TouchExtraPadding::ImVec2
+    IndentSpacing::Cfloat
+    ColumnsMinSpacing::Cfloat
+    ScrollbarSize::Cfloat
+    ScrollbarRounding::Cfloat
+    GrabMinSize::Cfloat
+    GrabRounding::Cfloat
+    LogSliderDeadzone::Cfloat
+    TabRounding::Cfloat
+    TabBorderSize::Cfloat
+    TabMinWidthForCloseButton::Cfloat
+    ColorButtonPosition::ImGuiDir
+    ButtonTextAlign::ImVec2
+    SelectableTextAlign::ImVec2
+    DisplayWindowPadding::ImVec2
+    DisplaySafeAreaPadding::ImVec2
+    MouseCursorScale::Cfloat
+    AntiAliasedLines::Bool
+    AntiAliasedLinesUseTex::Bool
+    AntiAliasedFill::Bool
+    CurveTessellationTol::Cfloat
+    CircleSegmentMaxError::Cfloat
+    Colors::NTuple{48, ImVec4}
+end
+
+struct ImGuiPayload
+    Data::Ptr{Cvoid}
+    DataSize::Cint
+    SourceId::ImGuiID
+    SourceParentId::ImGuiID
+    DataFrameCount::Cint
+    DataType::NTuple{33, Cchar}
+    Preview::Bool
+    Delivery::Bool
+end
+
+const ImGuiConfigFlags = Cint
+
+const ImGuiBackendFlags = Cint
+
+const ImFontAtlasFlags = Cint
+
+struct ImVector_ImFontPtr
+    Size::Cint
+    Capacity::Cint
+    # Data::Ptr{Ptr{ImFont}}
+    Data::Ptr{Ptr{Cvoid}}
+end
+
+function Base.getproperty(x::ImVector_ImFontPtr, f::Symbol)
+    f === :Data && return Ptr{Ptr{ImFont}}(getfield(x, f))
+    return getfield(x, f)
+end
+
+struct ImVector_ImFontAtlasCustomRect
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImFontAtlasCustomRect}
+end
+
+struct ImFontConfig
+    FontData::Ptr{Cvoid}
+    FontDataSize::Cint
+    FontDataOwnedByAtlas::Bool
+    FontNo::Cint
+    SizePixels::Cfloat
+    OversampleH::Cint
+    OversampleV::Cint
+    PixelSnapH::Bool
+    GlyphExtraSpacing::ImVec2
+    GlyphOffset::ImVec2
+    GlyphRanges::Ptr{ImWchar}
+    GlyphMinAdvanceX::Cfloat
+    GlyphMaxAdvanceX::Cfloat
+    MergeMode::Bool
+    RasterizerFlags::Cuint
+    RasterizerMultiply::Cfloat
+    EllipsisChar::ImWchar
+    Name::NTuple{40, Cchar}
+    # DstFont::Ptr{ImFont}
+    DstFont::Ptr{Cvoid}
+end
+
+function Base.getproperty(x::ImFontConfig, f::Symbol)
+    f === :DstFont && return Ptr{ImFont}(getfield(x, f))
+    return getfield(x, f)
+end
+
+struct ImVector_ImFontConfig
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImFontConfig}
+end
+
+struct ImFontAtlas
+    Locked::Bool
+    Flags::ImFontAtlasFlags
+    TexID::ImTextureID
+    TexDesiredWidth::Cint
+    TexGlyphPadding::Cint
+    TexPixelsAlpha8::Ptr{Cuchar}
+    TexPixelsRGBA32::Ptr{Cuint}
+    TexWidth::Cint
+    TexHeight::Cint
+    TexUvScale::ImVec2
+    TexUvWhitePixel::ImVec2
+    Fonts::ImVector_ImFontPtr
+    CustomRects::ImVector_ImFontAtlasCustomRect
+    ConfigData::ImVector_ImFontConfig
+    TexUvLines::NTuple{64, ImVec4}
+    PackIdMouseCursors::Cint
+    PackIdLines::Cint
+end
+
+struct ImFontGlyph
+    data::NTuple{40, UInt8}
+end
+
+function Base.getproperty(x::Ptr{ImFontGlyph}, f::Symbol)
+    f === :Codepoint && return Ptr{Cuint}(x + 0)
+    f === :Visible && return (Ptr{Cuint}(x + 3), 7, 1)
+    f === :AdvanceX && return Ptr{Cfloat}(x + 4)
+    f === :X0 && return Ptr{Cfloat}(x + 8)
+    f === :Y0 && return Ptr{Cfloat}(x + 12)
+    f === :X1 && return Ptr{Cfloat}(x + 16)
+    f === :Y1 && return Ptr{Cfloat}(x + 20)
+    f === :U0 && return Ptr{Cfloat}(x + 24)
+    f === :V0 && return Ptr{Cfloat}(x + 28)
+    f === :U1 && return Ptr{Cfloat}(x + 32)
+    f === :V1 && return Ptr{Cfloat}(x + 36)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::ImFontGlyph, f::Symbol)
+    r = Ref{ImFontGlyph}(x)
+    ptr = Base.unsafe_convert(Ptr{ImFontGlyph}, r)
+    fptr = getproperty(ptr, f)
+    begin
+        if fptr isa Ptr
+            return GC.@preserve(r, unsafe_load(fptr))
+        else
+            (baseptr, offset, width) = fptr
+            ty = eltype(baseptr)
+            i8 = GC.@preserve(r, unsafe_load(baseptr))
+            bitstr = bitstring(i8)
+            sig = bitstr[(end - offset) - (width - 1):end - offset]
+            zexted = lpad(sig, 8 * sizeof(ty), '0')
+            return parse(ty, zexted; base = 2)
+        end
+    end
+end
+
+function Base.setproperty!(x::Ptr{ImFontGlyph}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+struct ImVector_ImFontGlyph
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImFontGlyph}
+end
+
+const ImU8 = Cuchar
+
+struct ImFont
+    IndexAdvanceX::ImVector_float
+    FallbackAdvanceX::Cfloat
+    FontSize::Cfloat
+    IndexLookup::ImVector_ImWchar
+    Glyphs::ImVector_ImFontGlyph
+    FallbackGlyph::Ptr{ImFontGlyph}
+    ContainerAtlas::Ptr{ImFontAtlas}
+    ConfigData::Ptr{ImFontConfig}
+    ConfigDataCount::Cshort
+    FallbackChar::ImWchar
+    EllipsisChar::ImWchar
+    DirtyLookupTables::Bool
+    Scale::Cfloat
+    Ascent::Cfloat
+    Descent::Cfloat
+    MetricsTotalSurface::Cint
+    Used4kPagesMap::NTuple{2, ImU8}
+end
+
+const ImGuiKeyModFlags = Cint
+
+struct ImGuiIO
+    ConfigFlags::ImGuiConfigFlags
+    BackendFlags::ImGuiBackendFlags
+    DisplaySize::ImVec2
+    DeltaTime::Cfloat
+    IniSavingRate::Cfloat
+    IniFilename::Ptr{Cchar}
+    LogFilename::Ptr{Cchar}
+    MouseDoubleClickTime::Cfloat
+    MouseDoubleClickMaxDist::Cfloat
+    MouseDragThreshold::Cfloat
+    KeyMap::NTuple{22, Cint}
+    KeyRepeatDelay::Cfloat
+    KeyRepeatRate::Cfloat
+    UserData::Ptr{Cvoid}
+    Fonts::Ptr{ImFontAtlas}
+    FontGlobalScale::Cfloat
+    FontAllowUserScaling::Bool
+    FontDefault::Ptr{ImFont}
+    DisplayFramebufferScale::ImVec2
+    MouseDrawCursor::Bool
+    ConfigMacOSXBehaviors::Bool
+    ConfigInputTextCursorBlink::Bool
+    ConfigWindowsResizeFromEdges::Bool
+    ConfigWindowsMoveFromTitleBarOnly::Bool
+    ConfigWindowsMemoryCompactTimer::Cfloat
+    BackendPlatformName::Ptr{Cchar}
+    BackendRendererName::Ptr{Cchar}
+    BackendPlatformUserData::Ptr{Cvoid}
+    BackendRendererUserData::Ptr{Cvoid}
+    BackendLanguageUserData::Ptr{Cvoid}
+    GetClipboardTextFn::Ptr{Cvoid}
+    SetClipboardTextFn::Ptr{Cvoid}
+    ClipboardUserData::Ptr{Cvoid}
+    ImeSetInputScreenPosFn::Ptr{Cvoid}
+    ImeWindowHandle::Ptr{Cvoid}
+    RenderDrawListsFnUnused::Ptr{Cvoid}
+    MousePos::ImVec2
+    MouseDown::NTuple{5, Bool}
+    MouseWheel::Cfloat
+    MouseWheelH::Cfloat
+    KeyCtrl::Bool
+    KeyShift::Bool
+    KeyAlt::Bool
+    KeySuper::Bool
+    KeysDown::NTuple{512, Bool}
+    NavInputs::NTuple{21, Cfloat}
+    WantCaptureMouse::Bool
+    WantCaptureKeyboard::Bool
+    WantTextInput::Bool
+    WantSetMousePos::Bool
+    WantSaveIniSettings::Bool
+    NavActive::Bool
+    NavVisible::Bool
+    Framerate::Cfloat
+    MetricsRenderVertices::Cint
+    MetricsRenderIndices::Cint
+    MetricsRenderWindows::Cint
+    MetricsActiveWindows::Cint
+    MetricsActiveAllocations::Cint
+    MouseDelta::ImVec2
+    KeyMods::ImGuiKeyModFlags
+    MousePosPrev::ImVec2
+    MouseClickedPos::NTuple{5, ImVec2}
+    MouseClickedTime::NTuple{5, Cdouble}
+    MouseClicked::NTuple{5, Bool}
+    MouseDoubleClicked::NTuple{5, Bool}
+    MouseReleased::NTuple{5, Bool}
+    MouseDownOwned::NTuple{5, Bool}
+    MouseDownWasDoubleClick::NTuple{5, Bool}
+    MouseDownDuration::NTuple{5, Cfloat}
+    MouseDownDurationPrev::NTuple{5, Cfloat}
+    MouseDragMaxDistanceAbs::NTuple{5, ImVec2}
+    MouseDragMaxDistanceSqr::NTuple{5, Cfloat}
+    KeysDownDuration::NTuple{512, Cfloat}
+    KeysDownDurationPrev::NTuple{512, Cfloat}
+    NavInputsDownDuration::NTuple{21, Cfloat}
+    NavInputsDownDurationPrev::NTuple{21, Cfloat}
+    PenPressure::Cfloat
+    InputQueueSurrogate::ImWchar16
+    InputQueueCharacters::ImVector_ImWchar
+end
+
+struct ImDrawListSharedData
+    TexUvWhitePixel::ImVec2
+    Font::Ptr{ImFont}
+    FontSize::Cfloat
+    CurveTessellationTol::Cfloat
+    CircleSegmentMaxError::Cfloat
+    ClipRectFullscreen::ImVec4
+    InitialFlags::ImDrawListFlags
+    ArcFastVtx::NTuple{12, ImVec2}
+    CircleSegmentCounts::NTuple{64, ImU8}
+    TexUvLines::Ptr{ImVec4}
+end
+
+const ImU64 = UInt64
+
+@cenum ImGuiInputSource::UInt32 begin
+    ImGuiInputSource_None = 0
+    ImGuiInputSource_Mouse = 1
+    ImGuiInputSource_Nav = 2
+    ImGuiInputSource_NavKeyboard = 3
+    ImGuiInputSource_NavGamepad = 4
+    ImGuiInputSource_COUNT = 5
+end
+
+struct ImVector_ImGuiColorMod
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiColorMod}
+end
+
+struct ImVector_ImGuiStyleMod
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiStyleMod}
+end
+
+struct ImVector_ImGuiPopupData
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiPopupData}
+end
+
+const ImGuiNavMoveFlags = Cint
+
+@cenum ImGuiNavForward::UInt32 begin
+    ImGuiNavForward_None = 0
+    ImGuiNavForward_ForwardQueued = 1
+    ImGuiNavForward_ForwardActive = 2
+end
+
+struct ImDrawData
+    Valid::Bool
+    CmdLists::Ptr{Ptr{ImDrawList}}
+    CmdListsCount::Cint
+    TotalIdxCount::Cint
+    TotalVtxCount::Cint
+    DisplayPos::ImVec2
+    DisplaySize::ImVec2
+    FramebufferScale::ImVec2
+end
+
+const ImGuiMouseCursor = Cint
+
+const ImGuiDragDropFlags = Cint
+
+struct ImVector_unsigned_char
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{Cuchar}
+end
+
+struct ImVector_ImGuiTabBar
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiTabBar}
+end
+
+const ImPoolIdx = Cint
+
+struct ImPool_ImGuiTabBar
+    Buf::ImVector_ImGuiTabBar
+    Map::ImGuiStorage
+    FreeIdx::ImPoolIdx
+end
+
+struct ImVector_ImGuiPtrOrIndex
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiPtrOrIndex}
+end
+
+struct ImVector_ImGuiShrinkWidthItem
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiShrinkWidthItem}
+end
+
+const ImGuiColorEditFlags = Cint
+
+struct ImVector_ImGuiSettingsHandler
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiSettingsHandler}
+end
+
+struct ImVector_ImGuiWindowSettings
+    Size::Cint
+    Capacity::Cint
+    Data::Ptr{ImGuiWindowSettings}
+end
+
+struct ImChunkStream_ImGuiWindowSettings
+    Buf::ImVector_ImGuiWindowSettings
+end
+
+@cenum ImGuiLogType::UInt32 begin
+    ImGuiLogType_None = 0
+    ImGuiLogType_TTY = 1
+    ImGuiLogType_File = 2
+    ImGuiLogType_Buffer = 3
+    ImGuiLogType_Clipboard = 4
+end
+
+const ImFileHandle = Ptr{Libc.FILE}
+
+mutable struct ImGuiContext
+    Initialized::Bool
+    FontAtlasOwnedByContext::Bool
+    IO::ImGuiIO
+    Style::ImGuiStyle
+    Font::Ptr{ImFont}
+    FontSize::Cfloat
+    FontBaseSize::Cfloat
+    DrawListSharedData::ImDrawListSharedData
+    Time::Cdouble
+    FrameCount::Cint
+    FrameCountEnded::Cint
+    FrameCountRendered::Cint
+    WithinFrameScope::Bool
+    WithinFrameScopeWithImplicitWindow::Bool
+    WithinEndChild::Bool
+    TestEngineHookItems::Bool
+    TestEngineHookIdInfo::ImGuiID
+    TestEngine::Ptr{Cvoid}
+    Windows::ImVector_ImGuiWindowPtr
+    WindowsFocusOrder::ImVector_ImGuiWindowPtr
+    WindowsTempSortBuffer::ImVector_ImGuiWindowPtr
+    CurrentWindowStack::ImVector_ImGuiWindowPtr
+    WindowsById::ImGuiStorage
+    WindowsActiveCount::Cint
+    CurrentWindow::Ptr{ImGuiWindow}
+    HoveredWindow::Ptr{ImGuiWindow}
+    HoveredRootWindow::Ptr{ImGuiWindow}
+    HoveredWindowUnderMovingWindow::Ptr{ImGuiWindow}
+    MovingWindow::Ptr{ImGuiWindow}
+    WheelingWindow::Ptr{ImGuiWindow}
+    WheelingWindowRefMousePos::ImVec2
+    WheelingWindowTimer::Cfloat
+    HoveredId::ImGuiID
+    HoveredIdPreviousFrame::ImGuiID
+    HoveredIdAllowOverlap::Bool
+    HoveredIdDisabled::Bool
+    HoveredIdTimer::Cfloat
+    HoveredIdNotActiveTimer::Cfloat
+    ActiveId::ImGuiID
+    ActiveIdIsAlive::ImGuiID
+    ActiveIdTimer::Cfloat
+    ActiveIdIsJustActivated::Bool
+    ActiveIdAllowOverlap::Bool
+    ActiveIdNoClearOnFocusLoss::Bool
+    ActiveIdHasBeenPressedBefore::Bool
+    ActiveIdHasBeenEditedBefore::Bool
+    ActiveIdHasBeenEditedThisFrame::Bool
+    ActiveIdUsingNavDirMask::ImU32
+    ActiveIdUsingNavInputMask::ImU32
+    ActiveIdUsingKeyInputMask::ImU64
+    ActiveIdClickOffset::ImVec2
+    ActiveIdWindow::Ptr{ImGuiWindow}
+    ActiveIdSource::ImGuiInputSource
+    ActiveIdMouseButton::Cint
+    ActiveIdPreviousFrame::ImGuiID
+    ActiveIdPreviousFrameIsAlive::Bool
+    ActiveIdPreviousFrameHasBeenEditedBefore::Bool
+    ActiveIdPreviousFrameWindow::Ptr{ImGuiWindow}
+    LastActiveId::ImGuiID
+    LastActiveIdTimer::Cfloat
+    NextWindowData::ImGuiNextWindowData
+    NextItemData::ImGuiNextItemData
+    ColorModifiers::ImVector_ImGuiColorMod
+    StyleModifiers::ImVector_ImGuiStyleMod
+    FontStack::ImVector_ImFontPtr
+    OpenPopupStack::ImVector_ImGuiPopupData
+    BeginPopupStack::ImVector_ImGuiPopupData
+    NavWindow::Ptr{ImGuiWindow}
+    NavId::ImGuiID
+    NavFocusScopeId::ImGuiID
+    NavActivateId::ImGuiID
+    NavActivateDownId::ImGuiID
+    NavActivatePressedId::ImGuiID
+    NavInputId::ImGuiID
+    NavJustTabbedId::ImGuiID
+    NavJustMovedToId::ImGuiID
+    NavJustMovedToFocusScopeId::ImGuiID
+    NavJustMovedToKeyMods::ImGuiKeyModFlags
+    NavNextActivateId::ImGuiID
+    NavInputSource::ImGuiInputSource
+    NavScoringRect::ImRect
+    NavScoringCount::Cint
+    NavLayer::ImGuiNavLayer
+    NavIdTabCounter::Cint
+    NavIdIsAlive::Bool
+    NavMousePosDirty::Bool
+    NavDisableHighlight::Bool
+    NavDisableMouseHover::Bool
+    NavAnyRequest::Bool
+    NavInitRequest::Bool
+    NavInitRequestFromMove::Bool
+    NavInitResultId::ImGuiID
+    NavInitResultRectRel::ImRect
+    NavMoveRequest::Bool
+    NavMoveRequestFlags::ImGuiNavMoveFlags
+    NavMoveRequestForward::ImGuiNavForward
+    NavMoveRequestKeyMods::ImGuiKeyModFlags
+    NavMoveDir::ImGuiDir
+    NavMoveDirLast::ImGuiDir
+    NavMoveClipDir::ImGuiDir
+    NavMoveResultLocal::ImGuiNavMoveResult
+    NavMoveResultLocalVisibleSet::ImGuiNavMoveResult
+    NavMoveResultOther::ImGuiNavMoveResult
+    NavWrapRequestWindow::Ptr{ImGuiWindow}
+    NavWrapRequestFlags::ImGuiNavMoveFlags
+    NavWindowingTarget::Ptr{ImGuiWindow}
+    NavWindowingTargetAnim::Ptr{ImGuiWindow}
+    NavWindowingListWindow::Ptr{ImGuiWindow}
+    NavWindowingTimer::Cfloat
+    NavWindowingHighlightAlpha::Cfloat
+    NavWindowingToggleLayer::Bool
+    FocusRequestCurrWindow::Ptr{ImGuiWindow}
+    FocusRequestNextWindow::Ptr{ImGuiWindow}
+    FocusRequestCurrCounterRegular::Cint
+    FocusRequestCurrCounterTabStop::Cint
+    FocusRequestNextCounterRegular::Cint
+    FocusRequestNextCounterTabStop::Cint
+    FocusTabPressed::Bool
+    DrawData::ImDrawData
+    DrawDataBuilder::ImDrawDataBuilder
+    DimBgRatio::Cfloat
+    BackgroundDrawList::ImDrawList
+    ForegroundDrawList::ImDrawList
+    MouseCursor::ImGuiMouseCursor
+    DragDropActive::Bool
+    DragDropWithinSource::Bool
+    DragDropWithinTarget::Bool
+    DragDropSourceFlags::ImGuiDragDropFlags
+    DragDropSourceFrameCount::Cint
+    DragDropMouseButton::Cint
+    DragDropPayload::ImGuiPayload
+    DragDropTargetRect::ImRect
+    DragDropTargetId::ImGuiID
+    DragDropAcceptFlags::ImGuiDragDropFlags
+    DragDropAcceptIdCurrRectSurface::Cfloat
+    DragDropAcceptIdCurr::ImGuiID
+    DragDropAcceptIdPrev::ImGuiID
+    DragDropAcceptFrameCount::Cint
+    DragDropHoldJustPressedId::ImGuiID
+    DragDropPayloadBufHeap::ImVector_unsigned_char
+    DragDropPayloadBufLocal::NTuple{16, Cuchar}
+    CurrentTabBar::Ptr{ImGuiTabBar}
+    TabBars::ImPool_ImGuiTabBar
+    CurrentTabBarStack::ImVector_ImGuiPtrOrIndex
+    ShrinkWidthBuffer::ImVector_ImGuiShrinkWidthItem
+    LastValidMousePos::ImVec2
+    InputTextState::ImGuiInputTextState
+    InputTextPasswordFont::ImFont
+    TempInputId::ImGuiID
+    ColorEditOptions::ImGuiColorEditFlags
+    ColorEditLastHue::Cfloat
+    ColorEditLastSat::Cfloat
+    ColorEditLastColor::NTuple{3, Cfloat}
+    ColorPickerRef::ImVec4
+    SliderCurrentAccum::Cfloat
+    SliderCurrentAccumDirty::Bool
+    DragCurrentAccumDirty::Bool
+    DragCurrentAccum::Cfloat
+    DragSpeedDefaultRatio::Cfloat
+    ScrollbarClickDeltaToGrabCenter::Cfloat
+    TooltipOverrideCount::Cint
+    ClipboardHandlerData::ImVector_char
+    MenusIdSubmittedThisFrame::ImVector_ImGuiID
+    PlatformImePos::ImVec2
+    PlatformImeLastPos::ImVec2
+    PlatformLocaleDecimalPoint::Cchar
+    SettingsLoaded::Bool
+    SettingsDirtyTimer::Cfloat
+    SettingsIniData::ImGuiTextBuffer
+    SettingsHandlers::ImVector_ImGuiSettingsHandler
+    SettingsWindows::ImChunkStream_ImGuiWindowSettings
+    LogEnabled::Bool
+    LogType::ImGuiLogType
+    LogFile::ImFileHandle
+    LogBuffer::ImGuiTextBuffer
+    LogLinePosY::Cfloat
+    LogLineFirstItem::Bool
+    LogDepthRef::Cint
+    LogDepthToExpand::Cint
+    LogDepthToExpandDefault::Cint
+    DebugItemPickerActive::Bool
+    DebugItemPickerBreakId::ImGuiID
+    FramerateSecPerFrame::NTuple{120, Cfloat}
+    FramerateSecPerFrameIdx::Cint
+    FramerateSecPerFrameAccum::Cfloat
+    WantCaptureMouseNextFrame::Cint
+    WantCaptureKeyboardNextFrame::Cint
+    WantTextInputNextFrame::Cint
+    TempBuffer::NTuple{3073, Cchar}
+    ImGuiContext() = new()
+end
+
+const ImGuiMouseButton = Cint
+
+const ImU16 = Cushort
+
+const ImS32 = Cint
+
+const ImS64 = Int64
 
 mutable struct ImPlotInputMap
     PanButton::ImGuiMouseButton
@@ -37,6 +1312,7 @@ mutable struct ImPlotInputMap
     QueryToggleMod::ImGuiKeyModFlags
     HorizontalMod::ImGuiKeyModFlags
     VerticalMod::ImGuiKeyModFlags
+    ImPlotInputMap() = new()
 end
 
 mutable struct ImPlotStyle
@@ -72,6 +1348,7 @@ mutable struct ImPlotStyle
     UseLocalTime::Bool
     UseISO8601::Bool
     Use24HourClock::Bool
+    ImPlotStyle() = new()
 end
 
 struct ImPlotRange
@@ -82,11 +1359,13 @@ end
 mutable struct ImPlotLimits
     X::ImPlotRange
     Y::ImPlotRange
+    ImPlotLimits() = new()
 end
 
 mutable struct ImPlotPoint
     x::Cdouble
     y::Cdouble
+    ImPlotPoint() = new()
 end
 
 mutable struct ImPlotContext end
@@ -330,7 +1609,7 @@ function SetCurrentContext(ctx)
 end
 
 function BeginPlot(title_id, x_label, y_label, size, flags, x_flags, y_flags, y2_flags, y3_flags)
-    ccall((:ImPlot_BeginPlot, libcimplot), Bool, (Cstring, Cstring, Cstring, ImVec2, ImPlotFlags, ImPlotAxisFlags, ImPlotAxisFlags, ImPlotAxisFlags, ImPlotAxisFlags), title_id, x_label, y_label, size, flags, x_flags, y_flags, y2_flags, y3_flags)
+    ccall((:ImPlot_BeginPlot, libcimplot), Bool, (Ptr{Cchar}, Ptr{Cchar}, Ptr{Cchar}, ImVec2, ImPlotFlags, ImPlotAxisFlags, ImPlotAxisFlags, ImPlotAxisFlags, ImPlotAxisFlags), title_id, x_label, y_label, size, flags, x_flags, y_flags, y2_flags, y3_flags)
 end
 
 function EndPlot()
@@ -338,899 +1617,899 @@ function EndPlot()
 end
 
 function PlotLine(label_id, values::AbstractArray{Cfloat}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineFloatPtrInt, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotLineFloatPtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotLine(label_id, values::AbstractArray{Cdouble}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLinedoublePtrInt, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotLinedoublePtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotLine(label_id, values::AbstractArray{ImS8}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineS8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotLineS8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotLine(label_id, values::AbstractArray{ImU8}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineU8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotLineU8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotLine(label_id, values::AbstractArray{ImS16}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineS16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotLineS16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotLine(label_id, values::AbstractArray{ImU16}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineU16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotLineU16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotLine(label_id, values::AbstractArray{ImS32}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineS32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotLineS32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotLine(label_id, values::AbstractArray{ImU32}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineU32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotLineU32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotLine(label_id, values::AbstractArray{ImS64}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineS64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotLineS64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotLine(label_id, values::AbstractArray{ImU64}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineU64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotLineU64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotLine(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineFloatPtrFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotLineFloatPtrFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotLine(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLinedoublePtrdoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotLinedoublePtrdoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotLine(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineS8PtrS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotLineS8PtrS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotLine(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineU8PtrU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotLineU8PtrU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotLine(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineS16PtrS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotLineS16PtrS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotLine(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineU16PtrU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotLineU16PtrU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotLine(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineS32PtrS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotLineS32PtrS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotLine(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineU32PtrU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotLineU32PtrU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotLine(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineS64PtrS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotLineS64PtrS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotLine(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotLineU64PtrU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotLineU64PtrU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotScatter(label_id, values::AbstractArray{Cfloat}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterFloatPtrInt, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotScatterFloatPtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotScatter(label_id, values::AbstractArray{Cdouble}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterdoublePtrInt, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotScatterdoublePtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotScatter(label_id, values::AbstractArray{ImS8}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterS8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotScatterS8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotScatter(label_id, values::AbstractArray{ImU8}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterU8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotScatterU8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotScatter(label_id, values::AbstractArray{ImS16}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterS16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotScatterS16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotScatter(label_id, values::AbstractArray{ImU16}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterU16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotScatterU16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotScatter(label_id, values::AbstractArray{ImS32}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterS32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotScatterS32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotScatter(label_id, values::AbstractArray{ImU32}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterU32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotScatterU32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotScatter(label_id, values::AbstractArray{ImS64}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterS64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotScatterS64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotScatter(label_id, values::AbstractArray{ImU64}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterU64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotScatterU64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotScatter(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterFloatPtrFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotScatterFloatPtrFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotScatter(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterdoublePtrdoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotScatterdoublePtrdoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotScatter(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterS8PtrS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotScatterS8PtrS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotScatter(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterU8PtrU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotScatterU8PtrU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotScatter(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterS16PtrS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotScatterS16PtrS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotScatter(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterU16PtrU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotScatterU16PtrU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotScatter(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterS32PtrS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotScatterS32PtrS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotScatter(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterU32PtrU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotScatterU32PtrU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotScatter(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterS64PtrS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotScatterS64PtrS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotScatter(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotScatterU64PtrU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotScatterU64PtrU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairs(label_id, values::AbstractArray{Cfloat}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsFloatPtrInt, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStairsFloatPtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotStairs(label_id, values::AbstractArray{Cdouble}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsdoublePtrInt, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStairsdoublePtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotStairs(label_id, values::AbstractArray{ImS8}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsS8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStairsS8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotStairs(label_id, values::AbstractArray{ImU8}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsU8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStairsU8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotStairs(label_id, values::AbstractArray{ImS16}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsS16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStairsS16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotStairs(label_id, values::AbstractArray{ImU16}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsU16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStairsU16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotStairs(label_id, values::AbstractArray{ImS32}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsS32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStairsS32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotStairs(label_id, values::AbstractArray{ImU32}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsU32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStairsU32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotStairs(label_id, values::AbstractArray{ImS64}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsS64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStairsS64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotStairs(label_id, values::AbstractArray{ImU64}, count::Integer, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsU64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStairsU64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, xscale, x0, offset, stride)
 end
 
 function PlotStairs(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsFloatPtrFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotStairsFloatPtrFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairs(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsdoublePtrdoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotStairsdoublePtrdoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairs(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsS8PtrS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotStairsS8PtrS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairs(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsU8PtrU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotStairsU8PtrU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairs(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsS16PtrS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotStairsS16PtrS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairs(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsU16PtrU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotStairsU16PtrU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairs(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsS32PtrS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotStairsS32PtrS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairs(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsU32PtrU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotStairsU32PtrU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairs(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsS64PtrS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotStairsS64PtrS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairs(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStairsU64PtrU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotStairsU64PtrU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotStairsG(label_id, getter, data, count::Integer, offset::Integer)
-    ccall((:ImPlot_PlotStairsG, libcimplot), Cvoid, (Cstring, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint), label_id, getter, data, count, offset)
+    ccall((:ImPlot_PlotStairsG, libcimplot), Cvoid, (Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint), label_id, getter, data, count, offset)
 end
 
 function PlotShaded(label_id, values::AbstractArray{Cfloat}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedFloatPtrIntdoubledoubleInt, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotShadedFloatPtrIntdoubledoubleInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotShaded(label_id, values::AbstractArray{Cdouble}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadeddoublePtrIntdoubledoubleInt, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotShadeddoublePtrIntdoubledoubleInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotShaded(label_id, values::AbstractArray{ImS8}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS8PtrIntdoubledoubleInt, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotShadedS8PtrIntdoubledoubleInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotShaded(label_id, values::AbstractArray{ImU8}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU8PtrIntdoubledoubleInt, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotShadedU8PtrIntdoubledoubleInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotShaded(label_id, values::AbstractArray{ImS16}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS16PtrIntdoubledoubleInt, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotShadedS16PtrIntdoubledoubleInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotShaded(label_id, values::AbstractArray{ImU16}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU16PtrIntdoubledoubleInt, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotShadedU16PtrIntdoubledoubleInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotShaded(label_id, values::AbstractArray{ImS32}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS32PtrIntdoubledoubleInt, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotShadedS32PtrIntdoubledoubleInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotShaded(label_id, values::AbstractArray{ImU32}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU32PtrIntdoubledoubleInt, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotShadedU32PtrIntdoubledoubleInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotShaded(label_id, values::AbstractArray{ImS64}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS64PtrIntdoubledoubleInt, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotShadedS64PtrIntdoubledoubleInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotShaded(label_id, values::AbstractArray{ImU64}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU64PtrIntdoubledoubleInt, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotShadedU64PtrIntdoubledoubleInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedFloatPtrFloatPtrIntInt, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotShadedFloatPtrFloatPtrIntInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadeddoublePtrdoublePtrIntInt, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotShadeddoublePtrdoublePtrIntInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS8PtrS8PtrIntInt, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotShadedS8PtrS8PtrIntInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU8PtrU8PtrIntInt, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotShadedU8PtrU8PtrIntInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS16PtrS16PtrIntInt, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotShadedS16PtrS16PtrIntInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU16PtrU16PtrIntInt, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotShadedU16PtrU16PtrIntInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS32PtrS32PtrIntInt, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotShadedS32PtrS32PtrIntInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU32PtrU32PtrIntInt, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotShadedU32PtrU32PtrIntInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS64PtrS64PtrIntInt, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotShadedS64PtrS64PtrIntInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU64PtrU64PtrIntInt, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotShadedU64PtrU64PtrIntInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{Cfloat}, ys1::AbstractArray{Cfloat}, ys2::AbstractArray{Cfloat}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedFloatPtrFloatPtrFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
+    ccall((:ImPlot_PlotShadedFloatPtrFloatPtrFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{Cdouble}, ys1::AbstractArray{Cdouble}, ys2::AbstractArray{Cdouble}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadeddoublePtrdoublePtrdoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
+    ccall((:ImPlot_PlotShadeddoublePtrdoublePtrdoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImS8}, ys1::AbstractArray{ImS8}, ys2::AbstractArray{ImS8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS8PtrS8PtrS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
+    ccall((:ImPlot_PlotShadedS8PtrS8PtrS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImU8}, ys1::AbstractArray{ImU8}, ys2::AbstractArray{ImU8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU8PtrU8PtrU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
+    ccall((:ImPlot_PlotShadedU8PtrU8PtrU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImS16}, ys1::AbstractArray{ImS16}, ys2::AbstractArray{ImS16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS16PtrS16PtrS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
+    ccall((:ImPlot_PlotShadedS16PtrS16PtrS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImU16}, ys1::AbstractArray{ImU16}, ys2::AbstractArray{ImU16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU16PtrU16PtrU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
+    ccall((:ImPlot_PlotShadedU16PtrU16PtrU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImS32}, ys1::AbstractArray{ImS32}, ys2::AbstractArray{ImS32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS32PtrS32PtrS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
+    ccall((:ImPlot_PlotShadedS32PtrS32PtrS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImU32}, ys1::AbstractArray{ImU32}, ys2::AbstractArray{ImU32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU32PtrU32PtrU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
+    ccall((:ImPlot_PlotShadedU32PtrU32PtrU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImS64}, ys1::AbstractArray{ImS64}, ys2::AbstractArray{ImS64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedS64PtrS64PtrS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
+    ccall((:ImPlot_PlotShadedS64PtrS64PtrS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
 end
 
 function PlotShaded(label_id, xs::AbstractArray{ImU64}, ys1::AbstractArray{ImU64}, ys2::AbstractArray{ImU64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotShadedU64PtrU64PtrU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
+    ccall((:ImPlot_PlotShadedU64PtrU64PtrU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys1, ys2, count, offset, stride)
 end
 
 function PlotBars(label_id, values::AbstractArray{Cfloat}, count::Integer, width::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsFloatPtrInt, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsFloatPtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
 end
 
 function PlotBars(label_id, values::AbstractArray{Cdouble}, count::Integer, width::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsdoublePtrInt, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsdoublePtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
 end
 
 function PlotBars(label_id, values::AbstractArray{ImS8}, count::Integer, width::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsS8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsS8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
 end
 
 function PlotBars(label_id, values::AbstractArray{ImU8}, count::Integer, width::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsU8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsU8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
 end
 
 function PlotBars(label_id, values::AbstractArray{ImS16}, count::Integer, width::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsS16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsS16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
 end
 
 function PlotBars(label_id, values::AbstractArray{ImU16}, count::Integer, width::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsU16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsU16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
 end
 
 function PlotBars(label_id, values::AbstractArray{ImS32}, count::Integer, width::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsS32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsS32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
 end
 
 function PlotBars(label_id, values::AbstractArray{ImU32}, count::Integer, width::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsU32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsU32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
 end
 
 function PlotBars(label_id, values::AbstractArray{ImS64}, count::Integer, width::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsS64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsS64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
 end
 
 function PlotBars(label_id, values::AbstractArray{ImU64}, count::Integer, width::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsU64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsU64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, width, shift, offset, stride)
 end
 
 function PlotBars(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, count::Integer, width::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsFloatPtrFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
+    ccall((:ImPlot_PlotBarsFloatPtrFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
 end
 
 function PlotBars(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, count::Integer, width::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsdoublePtrdoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
+    ccall((:ImPlot_PlotBarsdoublePtrdoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
 end
 
 function PlotBars(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, count::Integer, width::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsS8PtrS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
+    ccall((:ImPlot_PlotBarsS8PtrS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
 end
 
 function PlotBars(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, count::Integer, width::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsU8PtrU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
+    ccall((:ImPlot_PlotBarsU8PtrU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
 end
 
 function PlotBars(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, count::Integer, width::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsS16PtrS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
+    ccall((:ImPlot_PlotBarsS16PtrS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
 end
 
 function PlotBars(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, count::Integer, width::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsU16PtrU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
+    ccall((:ImPlot_PlotBarsU16PtrU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
 end
 
 function PlotBars(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, count::Integer, width::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsS32PtrS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
+    ccall((:ImPlot_PlotBarsS32PtrS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
 end
 
 function PlotBars(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, count::Integer, width::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsU32PtrU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
+    ccall((:ImPlot_PlotBarsU32PtrU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
 end
 
 function PlotBars(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, count::Integer, width::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsS64PtrS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
+    ccall((:ImPlot_PlotBarsS64PtrS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
 end
 
 function PlotBars(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, count::Integer, width::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsU64PtrU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
+    ccall((:ImPlot_PlotBarsU64PtrU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, width, offset, stride)
 end
 
 function PlotBarsH(label_id, values::AbstractArray{Cfloat}, count::Integer, height::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHFloatPtrInt, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsHFloatPtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
 end
 
 function PlotBarsH(label_id, values::AbstractArray{Cdouble}, count::Integer, height::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHdoublePtrInt, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsHdoublePtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
 end
 
 function PlotBarsH(label_id, values::AbstractArray{ImS8}, count::Integer, height::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHS8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsHS8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
 end
 
 function PlotBarsH(label_id, values::AbstractArray{ImU8}, count::Integer, height::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHU8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsHU8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
 end
 
 function PlotBarsH(label_id, values::AbstractArray{ImS16}, count::Integer, height::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHS16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsHS16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
 end
 
 function PlotBarsH(label_id, values::AbstractArray{ImU16}, count::Integer, height::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHU16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsHU16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
 end
 
 function PlotBarsH(label_id, values::AbstractArray{ImS32}, count::Integer, height::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHS32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsHS32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
 end
 
 function PlotBarsH(label_id, values::AbstractArray{ImU32}, count::Integer, height::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHU32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsHU32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
 end
 
 function PlotBarsH(label_id, values::AbstractArray{ImS64}, count::Integer, height::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHS64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsHS64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
 end
 
 function PlotBarsH(label_id, values::AbstractArray{ImU64}, count::Integer, height::Real, shift::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHU64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
+    ccall((:ImPlot_PlotBarsHU64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Cint, Cdouble, Cdouble, Cint, Cint), label_id, values, count, height, shift, offset, stride)
 end
 
 function PlotBarsH(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, count::Integer, height::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHFloatPtrFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
+    ccall((:ImPlot_PlotBarsHFloatPtrFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
 end
 
 function PlotBarsH(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, count::Integer, height::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHdoublePtrdoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
+    ccall((:ImPlot_PlotBarsHdoublePtrdoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
 end
 
 function PlotBarsH(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, count::Integer, height::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHS8PtrS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
+    ccall((:ImPlot_PlotBarsHS8PtrS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
 end
 
 function PlotBarsH(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, count::Integer, height::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHU8PtrU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
+    ccall((:ImPlot_PlotBarsHU8PtrU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
 end
 
 function PlotBarsH(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, count::Integer, height::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHS16PtrS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
+    ccall((:ImPlot_PlotBarsHS16PtrS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
 end
 
 function PlotBarsH(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, count::Integer, height::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHU16PtrU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
+    ccall((:ImPlot_PlotBarsHU16PtrU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
 end
 
 function PlotBarsH(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, count::Integer, height::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHS32PtrS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
+    ccall((:ImPlot_PlotBarsHS32PtrS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
 end
 
 function PlotBarsH(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, count::Integer, height::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHU32PtrU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
+    ccall((:ImPlot_PlotBarsHU32PtrU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
 end
 
 function PlotBarsH(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, count::Integer, height::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHS64PtrS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
+    ccall((:ImPlot_PlotBarsHS64PtrS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
 end
 
 function PlotBarsH(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, count::Integer, height::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotBarsHU64PtrU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
+    ccall((:ImPlot_PlotBarsHU64PtrU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, height, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, err::AbstractArray{Cfloat}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsFloatPtrFloatPtrFloatPtrInt, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsFloatPtrFloatPtrFloatPtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, err::AbstractArray{Cdouble}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsdoublePtrdoublePtrdoublePtrInt, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsdoublePtrdoublePtrdoublePtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, err::AbstractArray{ImS8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsS8PtrS8PtrS8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsS8PtrS8PtrS8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, err::AbstractArray{ImU8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsU8PtrU8PtrU8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsU8PtrU8PtrU8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, err::AbstractArray{ImS16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsS16PtrS16PtrS16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsS16PtrS16PtrS16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, err::AbstractArray{ImU16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsU16PtrU16PtrU16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsU16PtrU16PtrU16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, err::AbstractArray{ImS32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsS32PtrS32PtrS32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsS32PtrS32PtrS32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, err::AbstractArray{ImU32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsU32PtrU32PtrU32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsU32PtrU32PtrU32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, err::AbstractArray{ImS64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsS64PtrS64PtrS64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsS64PtrS64PtrS64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, err::AbstractArray{ImU64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsU64PtrU64PtrU64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsU64PtrU64PtrU64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, neg::AbstractArray{Cfloat}, pos::AbstractArray{Cfloat}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsFloatPtrFloatPtrFloatPtrFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsFloatPtrFloatPtrFloatPtrFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, neg::AbstractArray{Cdouble}, pos::AbstractArray{Cdouble}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsdoublePtrdoublePtrdoublePtrdoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsdoublePtrdoublePtrdoublePtrdoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, neg::AbstractArray{ImS8}, pos::AbstractArray{ImS8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsS8PtrS8PtrS8PtrS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsS8PtrS8PtrS8PtrS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, neg::AbstractArray{ImU8}, pos::AbstractArray{ImU8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsU8PtrU8PtrU8PtrU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsU8PtrU8PtrU8PtrU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, neg::AbstractArray{ImS16}, pos::AbstractArray{ImS16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsS16PtrS16PtrS16PtrS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsS16PtrS16PtrS16PtrS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, neg::AbstractArray{ImU16}, pos::AbstractArray{ImU16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsU16PtrU16PtrU16PtrU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsU16PtrU16PtrU16PtrU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, neg::AbstractArray{ImS32}, pos::AbstractArray{ImS32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsS32PtrS32PtrS32PtrS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsS32PtrS32PtrS32PtrS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, neg::AbstractArray{ImU32}, pos::AbstractArray{ImU32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsU32PtrU32PtrU32PtrU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsU32PtrU32PtrU32PtrU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, neg::AbstractArray{ImS64}, pos::AbstractArray{ImS64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsS64PtrS64PtrS64PtrS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsS64PtrS64PtrS64PtrS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBars(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, neg::AbstractArray{ImU64}, pos::AbstractArray{ImU64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsU64PtrU64PtrU64PtrU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsU64PtrU64PtrU64PtrU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, err::AbstractArray{Cfloat}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHFloatPtrFloatPtrFloatPtrInt, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHFloatPtrFloatPtrFloatPtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, err::AbstractArray{Cdouble}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHdoublePtrdoublePtrdoublePtrInt, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHdoublePtrdoublePtrdoublePtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, err::AbstractArray{ImS8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHS8PtrS8PtrS8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHS8PtrS8PtrS8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, err::AbstractArray{ImU8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHU8PtrU8PtrU8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHU8PtrU8PtrU8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, err::AbstractArray{ImS16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHS16PtrS16PtrS16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHS16PtrS16PtrS16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, err::AbstractArray{ImU16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHU16PtrU16PtrU16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHU16PtrU16PtrU16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, err::AbstractArray{ImS32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHS32PtrS32PtrS32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHS32PtrS32PtrS32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, err::AbstractArray{ImU32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHU32PtrU32PtrU32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHU32PtrU32PtrU32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, err::AbstractArray{ImS64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHS64PtrS64PtrS64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHS64PtrS64PtrS64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, err::AbstractArray{ImU64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHU64PtrU64PtrU64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHU64PtrU64PtrU64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, err, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, neg::AbstractArray{Cfloat}, pos::AbstractArray{Cfloat}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHFloatPtrFloatPtrFloatPtrFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHFloatPtrFloatPtrFloatPtrFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, neg::AbstractArray{Cdouble}, pos::AbstractArray{Cdouble}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHdoublePtrdoublePtrdoublePtrdoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHdoublePtrdoublePtrdoublePtrdoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, neg::AbstractArray{ImS8}, pos::AbstractArray{ImS8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHS8PtrS8PtrS8PtrS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHS8PtrS8PtrS8PtrS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, neg::AbstractArray{ImU8}, pos::AbstractArray{ImU8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHU8PtrU8PtrU8PtrU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHU8PtrU8PtrU8PtrU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, neg::AbstractArray{ImS16}, pos::AbstractArray{ImS16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHS16PtrS16PtrS16PtrS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHS16PtrS16PtrS16PtrS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, neg::AbstractArray{ImU16}, pos::AbstractArray{ImU16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHU16PtrU16PtrU16PtrU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHU16PtrU16PtrU16PtrU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, neg::AbstractArray{ImS32}, pos::AbstractArray{ImS32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHS32PtrS32PtrS32PtrS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHS32PtrS32PtrS32PtrS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, neg::AbstractArray{ImU32}, pos::AbstractArray{ImU32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHU32PtrU32PtrU32PtrU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHU32PtrU32PtrU32PtrU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, neg::AbstractArray{ImS64}, pos::AbstractArray{ImS64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHS64PtrS64PtrS64PtrS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHS64PtrS64PtrS64PtrS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotErrorBarsH(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, neg::AbstractArray{ImU64}, pos::AbstractArray{ImU64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotErrorBarsHU64PtrU64PtrU64PtrU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
+    ccall((:ImPlot_PlotErrorBarsHU64PtrU64PtrU64PtrU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, neg, pos, count, offset, stride)
 end
 
 function PlotStems(label_id, values::AbstractArray{Cfloat}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsFloatPtrInt, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStemsFloatPtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotStems(label_id, values::AbstractArray{Cdouble}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsdoublePtrInt, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStemsdoublePtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotStems(label_id, values::AbstractArray{ImS8}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsS8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStemsS8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotStems(label_id, values::AbstractArray{ImU8}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsU8PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStemsU8PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotStems(label_id, values::AbstractArray{ImS16}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsS16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStemsS16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotStems(label_id, values::AbstractArray{ImU16}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsU16PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStemsU16PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotStems(label_id, values::AbstractArray{ImS32}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsS32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStemsS32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotStems(label_id, values::AbstractArray{ImU32}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsU32PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStemsU32PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotStems(label_id, values::AbstractArray{ImS64}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsS64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStemsS64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotStems(label_id, values::AbstractArray{ImU64}, count::Integer, y_ref::Real, xscale::Real, x0::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsU64PtrInt, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
+    ccall((:ImPlot_PlotStemsU64PtrInt, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Cint, Cdouble, Cdouble, Cdouble, Cint, Cint), label_id, values, count, y_ref, xscale, x0, offset, stride)
 end
 
 function PlotStems(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsFloatPtrFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotStemsFloatPtrFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotStems(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsdoublePtrdoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotStemsdoublePtrdoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotStems(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsS8PtrS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotStemsS8PtrS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotStems(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsU8PtrU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotStemsU8PtrU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotStems(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsS16PtrS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotStemsS16PtrS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotStems(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsU16PtrU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotStemsU16PtrU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotStems(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsS32PtrS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotStemsS32PtrS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotStems(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsU32PtrU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotStemsU32PtrU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotStems(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsS64PtrS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotStemsS64PtrS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotStems(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, count::Integer, y_ref::Real, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotStemsU64PtrU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
+    ccall((:ImPlot_PlotStemsU64PtrU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Cint, Cdouble, Cint, Cint), label_id, xs, ys, count, y_ref, offset, stride)
 end
 
 function PlotPieChart(label_ids, values::AbstractArray{Cfloat}, count::Integer, x::Real, y::Real, radius::Real, normalize, label_fmt, angle0::Real)
-    ccall((:ImPlot_PlotPieChartFloatPtr, libcimplot), Cvoid, (Ptr{Cstring}, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cdouble, Bool, Cstring, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
+    ccall((:ImPlot_PlotPieChartFloatPtr, libcimplot), Cvoid, (Ptr{Ptr{Cchar}}, Ref{Cfloat}, Cint, Cdouble, Cdouble, Cdouble, Bool, Ptr{Cchar}, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
 end
 
 function PlotPieChart(label_ids, values::AbstractArray{Cdouble}, count::Integer, x::Real, y::Real, radius::Real, normalize, label_fmt, angle0::Real)
-    ccall((:ImPlot_PlotPieChartdoublePtr, libcimplot), Cvoid, (Ptr{Cstring}, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cdouble, Bool, Cstring, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
+    ccall((:ImPlot_PlotPieChartdoublePtr, libcimplot), Cvoid, (Ptr{Ptr{Cchar}}, Ref{Cdouble}, Cint, Cdouble, Cdouble, Cdouble, Bool, Ptr{Cchar}, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
 end
 
 function PlotPieChart(label_ids, values::AbstractArray{ImS8}, count::Integer, x::Real, y::Real, radius::Real, normalize, label_fmt, angle0::Real)
-    ccall((:ImPlot_PlotPieChartS8Ptr, libcimplot), Cvoid, (Ptr{Cstring}, Ref{ImS8}, Cint, Cdouble, Cdouble, Cdouble, Bool, Cstring, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
+    ccall((:ImPlot_PlotPieChartS8Ptr, libcimplot), Cvoid, (Ptr{Ptr{Cchar}}, Ref{ImS8}, Cint, Cdouble, Cdouble, Cdouble, Bool, Ptr{Cchar}, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
 end
 
 function PlotPieChart(label_ids, values::AbstractArray{ImU8}, count::Integer, x::Real, y::Real, radius::Real, normalize, label_fmt, angle0::Real)
-    ccall((:ImPlot_PlotPieChartU8Ptr, libcimplot), Cvoid, (Ptr{Cstring}, Ref{ImU8}, Cint, Cdouble, Cdouble, Cdouble, Bool, Cstring, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
+    ccall((:ImPlot_PlotPieChartU8Ptr, libcimplot), Cvoid, (Ptr{Ptr{Cchar}}, Ref{ImU8}, Cint, Cdouble, Cdouble, Cdouble, Bool, Ptr{Cchar}, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
 end
 
 function PlotPieChart(label_ids, values::AbstractArray{ImS16}, count::Integer, x::Real, y::Real, radius::Real, normalize, label_fmt, angle0::Real)
-    ccall((:ImPlot_PlotPieChartS16Ptr, libcimplot), Cvoid, (Ptr{Cstring}, Ref{ImS16}, Cint, Cdouble, Cdouble, Cdouble, Bool, Cstring, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
+    ccall((:ImPlot_PlotPieChartS16Ptr, libcimplot), Cvoid, (Ptr{Ptr{Cchar}}, Ref{ImS16}, Cint, Cdouble, Cdouble, Cdouble, Bool, Ptr{Cchar}, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
 end
 
 function PlotPieChart(label_ids, values::AbstractArray{ImU16}, count::Integer, x::Real, y::Real, radius::Real, normalize, label_fmt, angle0::Real)
-    ccall((:ImPlot_PlotPieChartU16Ptr, libcimplot), Cvoid, (Ptr{Cstring}, Ref{ImU16}, Cint, Cdouble, Cdouble, Cdouble, Bool, Cstring, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
+    ccall((:ImPlot_PlotPieChartU16Ptr, libcimplot), Cvoid, (Ptr{Ptr{Cchar}}, Ref{ImU16}, Cint, Cdouble, Cdouble, Cdouble, Bool, Ptr{Cchar}, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
 end
 
 function PlotPieChart(label_ids, values::AbstractArray{ImS32}, count::Integer, x::Real, y::Real, radius::Real, normalize, label_fmt, angle0::Real)
-    ccall((:ImPlot_PlotPieChartS32Ptr, libcimplot), Cvoid, (Ptr{Cstring}, Ref{ImS32}, Cint, Cdouble, Cdouble, Cdouble, Bool, Cstring, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
+    ccall((:ImPlot_PlotPieChartS32Ptr, libcimplot), Cvoid, (Ptr{Ptr{Cchar}}, Ref{ImS32}, Cint, Cdouble, Cdouble, Cdouble, Bool, Ptr{Cchar}, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
 end
 
 function PlotPieChart(label_ids, values::AbstractArray{ImU32}, count::Integer, x::Real, y::Real, radius::Real, normalize, label_fmt, angle0::Real)
-    ccall((:ImPlot_PlotPieChartU32Ptr, libcimplot), Cvoid, (Ptr{Cstring}, Ref{ImU32}, Cint, Cdouble, Cdouble, Cdouble, Bool, Cstring, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
+    ccall((:ImPlot_PlotPieChartU32Ptr, libcimplot), Cvoid, (Ptr{Ptr{Cchar}}, Ref{ImU32}, Cint, Cdouble, Cdouble, Cdouble, Bool, Ptr{Cchar}, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
 end
 
 function PlotPieChart(label_ids, values::AbstractArray{ImS64}, count::Integer, x::Real, y::Real, radius::Real, normalize, label_fmt, angle0::Real)
-    ccall((:ImPlot_PlotPieChartS64Ptr, libcimplot), Cvoid, (Ptr{Cstring}, Ref{ImS64}, Cint, Cdouble, Cdouble, Cdouble, Bool, Cstring, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
+    ccall((:ImPlot_PlotPieChartS64Ptr, libcimplot), Cvoid, (Ptr{Ptr{Cchar}}, Ref{ImS64}, Cint, Cdouble, Cdouble, Cdouble, Bool, Ptr{Cchar}, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
 end
 
 function PlotPieChart(label_ids, values::AbstractArray{ImU64}, count::Integer, x::Real, y::Real, radius::Real, normalize, label_fmt, angle0::Real)
-    ccall((:ImPlot_PlotPieChartU64Ptr, libcimplot), Cvoid, (Ptr{Cstring}, Ref{ImU64}, Cint, Cdouble, Cdouble, Cdouble, Bool, Cstring, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
+    ccall((:ImPlot_PlotPieChartU64Ptr, libcimplot), Cvoid, (Ptr{Ptr{Cchar}}, Ref{ImU64}, Cint, Cdouble, Cdouble, Cdouble, Bool, Ptr{Cchar}, Cdouble), label_ids, values, count, x, y, radius, normalize, label_fmt, angle0)
 end
 
 function PlotHeatmap(label_id, values::AbstractArray{Cfloat}, rows::Integer, cols::Integer, scale_min::Real, scale_max::Real, label_fmt, bounds_min, bounds_max)
-    ccall((:ImPlot_PlotHeatmapFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Cint, Cint, Cdouble, Cdouble, Cstring, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
+    ccall((:ImPlot_PlotHeatmapFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Cint, Cint, Cdouble, Cdouble, Ptr{Cchar}, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
 end
 
 function PlotHeatmap(label_id, values::AbstractArray{Cdouble}, rows::Integer, cols::Integer, scale_min::Real, scale_max::Real, label_fmt, bounds_min, bounds_max)
-    ccall((:ImPlot_PlotHeatmapdoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Cint, Cint, Cdouble, Cdouble, Cstring, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
+    ccall((:ImPlot_PlotHeatmapdoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Cint, Cint, Cdouble, Cdouble, Ptr{Cchar}, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
 end
 
 function PlotHeatmap(label_id, values::AbstractArray{ImS8}, rows::Integer, cols::Integer, scale_min::Real, scale_max::Real, label_fmt, bounds_min, bounds_max)
-    ccall((:ImPlot_PlotHeatmapS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Cint, Cint, Cdouble, Cdouble, Cstring, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
+    ccall((:ImPlot_PlotHeatmapS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Cint, Cint, Cdouble, Cdouble, Ptr{Cchar}, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
 end
 
 function PlotHeatmap(label_id, values::AbstractArray{ImU8}, rows::Integer, cols::Integer, scale_min::Real, scale_max::Real, label_fmt, bounds_min, bounds_max)
-    ccall((:ImPlot_PlotHeatmapU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Cint, Cint, Cdouble, Cdouble, Cstring, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
+    ccall((:ImPlot_PlotHeatmapU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Cint, Cint, Cdouble, Cdouble, Ptr{Cchar}, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
 end
 
 function PlotHeatmap(label_id, values::AbstractArray{ImS16}, rows::Integer, cols::Integer, scale_min::Real, scale_max::Real, label_fmt, bounds_min, bounds_max)
-    ccall((:ImPlot_PlotHeatmapS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Cint, Cint, Cdouble, Cdouble, Cstring, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
+    ccall((:ImPlot_PlotHeatmapS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Cint, Cint, Cdouble, Cdouble, Ptr{Cchar}, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
 end
 
 function PlotHeatmap(label_id, values::AbstractArray{ImU16}, rows::Integer, cols::Integer, scale_min::Real, scale_max::Real, label_fmt, bounds_min, bounds_max)
-    ccall((:ImPlot_PlotHeatmapU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Cint, Cint, Cdouble, Cdouble, Cstring, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
+    ccall((:ImPlot_PlotHeatmapU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Cint, Cint, Cdouble, Cdouble, Ptr{Cchar}, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
 end
 
 function PlotHeatmap(label_id, values::AbstractArray{ImS32}, rows::Integer, cols::Integer, scale_min::Real, scale_max::Real, label_fmt, bounds_min, bounds_max)
-    ccall((:ImPlot_PlotHeatmapS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Cint, Cint, Cdouble, Cdouble, Cstring, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
+    ccall((:ImPlot_PlotHeatmapS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Cint, Cint, Cdouble, Cdouble, Ptr{Cchar}, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
 end
 
 function PlotHeatmap(label_id, values::AbstractArray{ImU32}, rows::Integer, cols::Integer, scale_min::Real, scale_max::Real, label_fmt, bounds_min, bounds_max)
-    ccall((:ImPlot_PlotHeatmapU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Cint, Cint, Cdouble, Cdouble, Cstring, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
+    ccall((:ImPlot_PlotHeatmapU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Cint, Cint, Cdouble, Cdouble, Ptr{Cchar}, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
 end
 
 function PlotHeatmap(label_id, values::AbstractArray{ImS64}, rows::Integer, cols::Integer, scale_min::Real, scale_max::Real, label_fmt, bounds_min, bounds_max)
-    ccall((:ImPlot_PlotHeatmapS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Cint, Cint, Cdouble, Cdouble, Cstring, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
+    ccall((:ImPlot_PlotHeatmapS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Cint, Cint, Cdouble, Cdouble, Ptr{Cchar}, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
 end
 
 function PlotHeatmap(label_id, values::AbstractArray{ImU64}, rows::Integer, cols::Integer, scale_min::Real, scale_max::Real, label_fmt, bounds_min, bounds_max)
-    ccall((:ImPlot_PlotHeatmapU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Cint, Cint, Cdouble, Cdouble, Cstring, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
+    ccall((:ImPlot_PlotHeatmapU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Cint, Cint, Cdouble, Cdouble, Ptr{Cchar}, ImPlotPoint, ImPlotPoint), label_id, values, rows, cols, scale_min, scale_max, label_fmt, bounds_min, bounds_max)
 end
 
 function PlotDigital(label_id, xs::AbstractArray{Cfloat}, ys::AbstractArray{Cfloat}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotDigitalFloatPtr, libcimplot), Cvoid, (Cstring, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotDigitalFloatPtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cfloat}, Ref{Cfloat}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotDigital(label_id, xs::AbstractArray{Cdouble}, ys::AbstractArray{Cdouble}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotDigitaldoublePtr, libcimplot), Cvoid, (Cstring, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotDigitaldoublePtr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{Cdouble}, Ref{Cdouble}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotDigital(label_id, xs::AbstractArray{ImS8}, ys::AbstractArray{ImS8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotDigitalS8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotDigitalS8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS8}, Ref{ImS8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotDigital(label_id, xs::AbstractArray{ImU8}, ys::AbstractArray{ImU8}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotDigitalU8Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotDigitalU8Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU8}, Ref{ImU8}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotDigital(label_id, xs::AbstractArray{ImS16}, ys::AbstractArray{ImS16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotDigitalS16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotDigitalS16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS16}, Ref{ImS16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotDigital(label_id, xs::AbstractArray{ImU16}, ys::AbstractArray{ImU16}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotDigitalU16Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotDigitalU16Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU16}, Ref{ImU16}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotDigital(label_id, xs::AbstractArray{ImS32}, ys::AbstractArray{ImS32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotDigitalS32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotDigitalS32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS32}, Ref{ImS32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotDigital(label_id, xs::AbstractArray{ImU32}, ys::AbstractArray{ImU32}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotDigitalU32Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotDigitalU32Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU32}, Ref{ImU32}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotDigital(label_id, xs::AbstractArray{ImS64}, ys::AbstractArray{ImS64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotDigitalS64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotDigitalS64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImS64}, Ref{ImS64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotDigital(label_id, xs::AbstractArray{ImU64}, ys::AbstractArray{ImU64}, count::Integer, offset::Integer, stride::Integer)
-    ccall((:ImPlot_PlotDigitalU64Ptr, libcimplot), Cvoid, (Cstring, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
+    ccall((:ImPlot_PlotDigitalU64Ptr, libcimplot), Cvoid, (Ptr{Cchar}, Ref{ImU64}, Ref{ImU64}, Cint, Cint, Cint), label_id, xs, ys, count, offset, stride)
 end
 
 function PlotImage(label_id, user_texture_id, bounds_min, bounds_max, uv0, uv1, tint_col)
-    ccall((:ImPlot_PlotImage, libcimplot), Cvoid, (Cstring, ImTextureID, ImPlotPoint, ImPlotPoint, ImVec2, ImVec2, ImVec4), label_id, user_texture_id, bounds_min, bounds_max, uv0, uv1, tint_col)
+    ccall((:ImPlot_PlotImage, libcimplot), Cvoid, (Ptr{Cchar}, ImTextureID, ImPlotPoint, ImPlotPoint, ImVec2, ImVec2, ImVec4), label_id, user_texture_id, bounds_min, bounds_max, uv0, uv1, tint_col)
 end
 
 function PlotText(text, x::Real, y::Real, vertical, pix_offset)
-    ccall((:ImPlot_PlotText, libcimplot), Cvoid, (Cstring, Cdouble, Cdouble, Bool, ImVec2), text, x, y, vertical, pix_offset)
+    ccall((:ImPlot_PlotText, libcimplot), Cvoid, (Ptr{Cchar}, Cdouble, Cdouble, Bool, ImVec2), text, x, y, vertical, pix_offset)
 end
 
 function PlotDummy(label_id)
-    ccall((:ImPlot_PlotDummy, libcimplot), Cvoid, (Cstring,), label_id)
+    ccall((:ImPlot_PlotDummy, libcimplot), Cvoid, (Ptr{Cchar},), label_id)
 end
 
 function SetNextPlotLimits(xmin, xmax, ymin, ymax, cond)
@@ -1254,19 +2533,19 @@ function FitNextPlotAxes(x, y, y2, y3)
 end
 
 function SetNextPlotTicksXdoublePtr(values, n_ticks, labels, show_default)
-    ccall((:ImPlot_SetNextPlotTicksXdoublePtr, libcimplot), Cvoid, (Ptr{Cdouble}, Cint, Ptr{Cstring}, Bool), values, n_ticks, labels, show_default)
+    ccall((:ImPlot_SetNextPlotTicksXdoublePtr, libcimplot), Cvoid, (Ptr{Cdouble}, Cint, Ptr{Ptr{Cchar}}, Bool), values, n_ticks, labels, show_default)
 end
 
 function SetNextPlotTicksXdouble(x_min, x_max, n_ticks, labels, show_default)
-    ccall((:ImPlot_SetNextPlotTicksXdouble, libcimplot), Cvoid, (Cdouble, Cdouble, Cint, Ptr{Cstring}, Bool), x_min, x_max, n_ticks, labels, show_default)
+    ccall((:ImPlot_SetNextPlotTicksXdouble, libcimplot), Cvoid, (Cdouble, Cdouble, Cint, Ptr{Ptr{Cchar}}, Bool), x_min, x_max, n_ticks, labels, show_default)
 end
 
 function SetNextPlotTicksYdoublePtr(values, n_ticks, labels, show_default, y_axis)
-    ccall((:ImPlot_SetNextPlotTicksYdoublePtr, libcimplot), Cvoid, (Ptr{Cdouble}, Cint, Ptr{Cstring}, Bool, ImPlotYAxis), values, n_ticks, labels, show_default, y_axis)
+    ccall((:ImPlot_SetNextPlotTicksYdoublePtr, libcimplot), Cvoid, (Ptr{Cdouble}, Cint, Ptr{Ptr{Cchar}}, Bool, ImPlotYAxis), values, n_ticks, labels, show_default, y_axis)
 end
 
 function SetNextPlotTicksYdouble(y_min, y_max, n_ticks, labels, show_default, y_axis)
-    ccall((:ImPlot_SetNextPlotTicksYdouble, libcimplot), Cvoid, (Cdouble, Cdouble, Cint, Ptr{Cstring}, Bool, ImPlotYAxis), y_min, y_max, n_ticks, labels, show_default, y_axis)
+    ccall((:ImPlot_SetNextPlotTicksYdouble, libcimplot), Cvoid, (Cdouble, Cdouble, Cint, Ptr{Ptr{Cchar}}, Bool, ImPlotYAxis), y_min, y_max, n_ticks, labels, show_default, y_axis)
 end
 
 function SetPlotYAxis(y_axis)
@@ -1330,15 +2609,15 @@ function GetPlotQuery(pOut, y_axis)
 end
 
 function DragLineX(id, x_value, show_label, col, thickness)
-    ccall((:ImPlot_DragLineX, libcimplot), Bool, (Cstring, Ptr{Cdouble}, Bool, ImVec4, Cfloat), id, x_value, show_label, col, thickness)
+    ccall((:ImPlot_DragLineX, libcimplot), Bool, (Ptr{Cchar}, Ptr{Cdouble}, Bool, ImVec4, Cfloat), id, x_value, show_label, col, thickness)
 end
 
 function DragLineY(id, y_value, show_label, col, thickness)
-    ccall((:ImPlot_DragLineY, libcimplot), Bool, (Cstring, Ptr{Cdouble}, Bool, ImVec4, Cfloat), id, y_value, show_label, col, thickness)
+    ccall((:ImPlot_DragLineY, libcimplot), Bool, (Ptr{Cchar}, Ptr{Cdouble}, Bool, ImVec4, Cfloat), id, y_value, show_label, col, thickness)
 end
 
 function DragPoint(id, x, y, show_label, col, radius)
-    ccall((:ImPlot_DragPoint, libcimplot), Bool, (Cstring, Ptr{Cdouble}, Ptr{Cdouble}, Bool, ImVec4, Cfloat), id, x, y, show_label, col, radius)
+    ccall((:ImPlot_DragPoint, libcimplot), Bool, (Ptr{Cchar}, Ptr{Cdouble}, Ptr{Cdouble}, Bool, ImVec4, Cfloat), id, x, y, show_label, col, radius)
 end
 
 function SetLegendLocation(location, orientation, outside)
@@ -1350,11 +2629,11 @@ function SetMousePosLocation(location)
 end
 
 function IsLegendEntryHovered(label_id)
-    ccall((:ImPlot_IsLegendEntryHovered, libcimplot), Bool, (Cstring,), label_id)
+    ccall((:ImPlot_IsLegendEntryHovered, libcimplot), Bool, (Ptr{Cchar},), label_id)
 end
 
 function BeginLegendDragDropSource(label_id, flags)
-    ccall((:ImPlot_BeginLegendDragDropSource, libcimplot), Bool, (Cstring, ImGuiDragDropFlags), label_id, flags)
+    ccall((:ImPlot_BeginLegendDragDropSource, libcimplot), Bool, (Ptr{Cchar}, ImGuiDragDropFlags), label_id, flags)
 end
 
 function EndLegendDragDropSource()
@@ -1362,7 +2641,7 @@ function EndLegendDragDropSource()
 end
 
 function BeginLegendPopup(label_id, mouse_button)
-    ccall((:ImPlot_BeginLegendPopup, libcimplot), Bool, (Cstring, ImGuiMouseButton), label_id, mouse_button)
+    ccall((:ImPlot_BeginLegendPopup, libcimplot), Bool, (Ptr{Cchar}, ImGuiMouseButton), label_id, mouse_button)
 end
 
 function EndLegendPopup()
@@ -1438,11 +2717,11 @@ function GetLastItemColor(pOut)
 end
 
 function GetStyleColorName(idx)
-    ccall((:ImPlot_GetStyleColorName, libcimplot), Cstring, (ImPlotCol,), idx)
+    ccall((:ImPlot_GetStyleColorName, libcimplot), Ptr{Cchar}, (ImPlotCol,), idx)
 end
 
 function GetMarkerName(idx)
-    ccall((:ImPlot_GetMarkerName, libcimplot), Cstring, (ImPlotMarker,), idx)
+    ccall((:ImPlot_GetMarkerName, libcimplot), Ptr{Cchar}, (ImPlotMarker,), idx)
 end
 
 function PushColormapPlotColormap(colormap)
@@ -1486,7 +2765,7 @@ function ShowColormapScale(scale_min, scale_max, height)
 end
 
 function GetColormapName(colormap)
-    ccall((:ImPlot_GetColormapName, libcimplot), Cstring, (ImPlotColormap,), colormap)
+    ccall((:ImPlot_GetColormapName, libcimplot), Ptr{Cchar}, (ImPlotColormap,), colormap)
 end
 
 function GetInputMap()
@@ -1506,11 +2785,11 @@ function PopPlotClipRect()
 end
 
 function ShowStyleSelector(label)
-    ccall((:ImPlot_ShowStyleSelector, libcimplot), Bool, (Cstring,), label)
+    ccall((:ImPlot_ShowStyleSelector, libcimplot), Bool, (Ptr{Cchar},), label)
 end
 
 function ShowColormapSelector(label)
-    ccall((:ImPlot_ShowColormapSelector, libcimplot), Bool, (Cstring,), label)
+    ccall((:ImPlot_ShowColormapSelector, libcimplot), Bool, (Ptr{Cchar},), label)
 end
 
 function ShowStyleEditor(ref)
@@ -1534,36 +2813,36 @@ function ShowDemoWindow(p_open)
 end
 
 function PlotLineG(label_id, getter, data, count::Integer, offset::Integer)
-    ccall((:ImPlot_PlotLineG, libcimplot), Cvoid, (Cstring, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint), label_id, getter, data, count, offset)
+    ccall((:ImPlot_PlotLineG, libcimplot), Cvoid, (Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint), label_id, getter, data, count, offset)
 end
 
 function PlotScatterG(label_id, getter, data, count::Integer, offset::Integer)
-    ccall((:ImPlot_PlotScatterG, libcimplot), Cvoid, (Cstring, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint), label_id, getter, data, count, offset)
+    ccall((:ImPlot_PlotScatterG, libcimplot), Cvoid, (Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint), label_id, getter, data, count, offset)
 end
 
 function PlotShadedG(label_id, getter1, data1, getter2, data2, count::Integer, offset::Integer)
-    ccall((:ImPlot_PlotShadedG, libcimplot), Cvoid, (Cstring, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint), label_id, getter1, data1, getter2, data2, count, offset)
+    ccall((:ImPlot_PlotShadedG, libcimplot), Cvoid, (Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint), label_id, getter1, data1, getter2, data2, count, offset)
 end
 
 function PlotBarsG(label_id, getter, data, count::Integer, width::Real, offset::Integer)
-    ccall((:ImPlot_PlotBarsG, libcimplot), Cvoid, (Cstring, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cdouble, Cint), label_id, getter, data, count, width, offset)
+    ccall((:ImPlot_PlotBarsG, libcimplot), Cvoid, (Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cdouble, Cint), label_id, getter, data, count, width, offset)
 end
 
 function PlotBarsH(label_id, getter, data, count::Integer, height::Real, offset::Integer)
-    ccall((:ImPlot_PlotBarsHG, libcimplot), Cvoid, (Cstring, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cdouble, Cint), label_id, getter, data, count, height, offset)
+    ccall((:ImPlot_PlotBarsHG, libcimplot), Cvoid, (Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cdouble, Cint), label_id, getter, data, count, height, offset)
 end
 
 function PlotDigitalG(label_id, getter, data, count::Integer, offset::Integer)
-    ccall((:ImPlot_PlotDigitalG, libcimplot), Cvoid, (Cstring, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint), label_id, getter, data, count, offset)
+    ccall((:ImPlot_PlotDigitalG, libcimplot), Cvoid, (Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint), label_id, getter, data, count, offset)
 end
 
 # Skipping MacroDefinition: API __attribute__ ( ( __visibility__ ( "default" ) ) )
 
 # Skipping MacroDefinition: EXTERN extern
 
-# Skipping MacroDefinition: CIMGUI_API EXTERN API
+const CIMGUI_API = EXTERN(API)
 
-# Skipping MacroDefinition: CONST const
+const CONST = $(Expr(:incomplete, "incomplete: premature end of input"))
 
 export ImPlotPoint, ImPlotRange, ImPlotLimits, ImPlotStyle, ImPlotInputMap, ImPlotContext
 export CreateContext, DestroyContext, GetCurrentContext, SetCurrentContext, SetImGuiContext
@@ -1581,11 +2860,9 @@ export ShowStyleSelector, ShowColormapSelector, ShowUserGuide, ShowDemoWindow
 
 # exports
 const PREFIXES = ["ImPlotFlags_", "ImPlotAxisFlags_", "ImPlotCol_", "ImPlotStyleVar_", "ImPlotMarker_", "ImPlotColormap_", "ImPlotLocation_", "ImPlotOrientation_", "ImPlotYAxis_"]
-foreach(names(@__MODULE__; all=true)) do s
-    for prefix in PREFIXES
-        if startswith(string(s), prefix)
-            @eval export $s
-        end
+for name in names(@__MODULE__; all=true), prefix in PREFIXES
+    if startswith(string(name), prefix)
+        @eval export $name
     end
 end
 

--- a/src/libcimplot.jl
+++ b/src/libcimplot.jl
@@ -4,6 +4,22 @@ using CEnum
 
 using CImPlot_jll
 
+using CImGui
+
+# import CImGui:
+#     # Vector primitives:
+#     ImVec2, ImVec4,
+#     # Enums
+#     ImGuiMouseButton, ImGuiKeyModFlags, ImGuiCond, ImGuiDragDropFlags,
+#     # Primitive type aliases; uncomment after CImGui update
+#     #=ImS8,=# ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64,
+#     ImTextureID,
+#     ImDrawList,
+#     ImGuiContext
+
+# #Temporary patch; CImGui.jl v1.79.0 aliases ImS8 incorrectly
+# const ImS8 = Int8
+
 
 struct ImGuiPtrOrIndex
     Ptr::Ptr{Cvoid}
@@ -2839,10 +2855,6 @@ end
 # Skipping MacroDefinition: API __attribute__ ( ( __visibility__ ( "default" ) ) )
 
 # Skipping MacroDefinition: EXTERN extern
-
-const CIMGUI_API = EXTERN(API)
-
-const CONST = $(Expr(:incomplete, "incomplete: premature end of input"))
 
 export ImPlotPoint, ImPlotRange, ImPlotLimits, ImPlotStyle, ImPlotInputMap, ImPlotContext
 export CreateContext, DestroyContext, GetCurrentContext, SetCurrentContext, SetImGuiContext


### PR DESCRIPTION
Now Clang.jl can detect all of those definitions in the system headers(or any include dir passed by `-isystem`), so there is no need to add those `@add_def`s. Feel free to add those `@def`s again if you don't like the duplicated bindings from CImGui, `@add_def` always has a high priority.