### PR TITLE
Restrict LibCImGui.jl compat bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
 [compat]
 CEnum = "0.4"
-LibCImGui = "1.82.2"
+LibCImGui = "~1.82"
 Setfield = "1"
 julia = "1.6"
 


### PR DESCRIPTION
Similarly to https://github.com/Gnimuc/CImGui.jl/pull/90, this restricts the compat bounds so we don't break anything while upgrading the other packages. I think if this is merged it ought to be put in a patch release.